### PR TITLE
feat: Generate PDF/HTML on release event with GitHub Actions

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,0 +1,53 @@
+# This is a basic workflow to help you get started with Actions
+
+name: release book
+
+# Controls when the workflow will run
+on:
+  release:
+    types: 
+      [released]
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: mkdir output
+        run: mkdir output
+
+      - name: pandoc is converting lkmpg.tex to lkmpg.pdf
+        uses: docker://pandoc/latex:2.14.1
+        with:
+          args: "-o ./output/lkmpg.pdf lkmpg.tex" 
+      
+      - name: pandoc is converting lkmpg.tex to index.html
+        uses: docker://pandoc/core:2.14.1
+        with:
+          args: "-o ./output/index.html -s lkmpg.tex" 
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: output
+          git-config-name: ghPageBot
+    
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./output/index.html
+            ./output/lkmpg.pdf


### PR DESCRIPTION
this feature will trigger github action to generating book on [github released event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release) and the book will be uploaded to release assets


## Github Page Setting
repo owner should set repo setting like this pic
![image](https://user-images.githubusercontent.com/9102619/127386608-5bf50fef-cb78-42fe-b793-d500208dda63.png)
