### PR TITLE
feat: add auto generating book on push by github action

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -26,7 +26,7 @@ jobs:
         run: mkdir output
 
       - name: pandoc is converting lkmpg.tex to lkmpg.pdf
-        uses: docker://pandoc/latex:2.14.1
+        uses: docker://pandoc/ubuntu-latex:2.14.1
         with:
           args: "-o ./output/lkmpg.pdf lkmpg.tex" 
       

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -1,0 +1,49 @@
+# This is a basic workflow to help you get started with Actions
+
+name: auto generate book
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: mkdir output
+        run: mkdir output
+
+      - name: pandoc is converting lkmpg.tex to lkmpg.pdf
+        uses: docker://pandoc/latex:2.14.1
+        with:
+          args: "-o ./output/lkmpg.pdf lkmpg.tex" 
+      
+      - name: pandoc is converting lkmpg.tex to index.html
+        uses: docker://pandoc/core:2.14.1
+        with:
+          args: "-o ./output/index.html -s lkmpg.tex" 
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: output
+          git-config-name: ghPageBot
+      
+      - name: Upload PDF file
+        uses: actions/upload-artifact@v2
+        with:
+          name: lkmpg
+          path: ./output


### PR DESCRIPTION
this feature will trigger GitHub action to generating book on GitHub push event and the book will be uploaded to GitHub action artifacts


![image](https://user-images.githubusercontent.com/9102619/127388180-1548f055-954c-4b00-ad69-a3965d971640.png)
