### PR TITLE
Generate HTML via make4ht

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,15 @@ _minted-lkmpg
 *.out
 lkmpg.pdf
 *.toc
+
+# make4ht
+*.html
+*.svg 
+*.tmp
+*.css 
+*.4ct 
+*.4tc 
+*.dvi 
+*.lg 
+*.idv
+*.xref

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ all: lkmpg.tex
 	bibtex main >/dev/null || echo
 	pdflatex -shell-escape $< 2>/dev/null >/dev/null
 
+html: lkmpg.tex html.cfg
+	make4ht --shell-escape --utf8 --format html5 --config html.cfg --output-dir html lkmpg.tex
+	ln -sf lkmpg.html html/index.html
+	rm -f  lkmpg.xref lkmpg.tmp lkmpg.html lkmpg.css lkmpg.4ct lkmpg.4tc lkmpg.dvi lkmpg.lg lkmpg.idv lkmpg*.svg lkmpg.log lkmpg.aux 
+
 clean:
 	rm -f *.dvi *.aux *.log *.ps *.pdf *.out lkmpg.bbl lkmpg.blg lkmpg.lof lkmpg.toc
 	rm -rf _minted-lkmpg
+	rm -rf html
+
+.PHONY: html

--- a/html.cfg
+++ b/html.cfg
@@ -1,0 +1,36 @@
+\Preamble{xhtml}
+
+\Configure{tableofcontents*}{chapter,section,subsection}
+
+\Css{* :not(img) {
+    max-width: 100\%;
+    width: 50vw; 
+    height: auto;
+    margin: 0 auto;
+}}
+
+\Css{* {
+    font-size: 1vw;
+}}
+
+\Css{.ecrm-0500 { 
+    font-size: 70\%;
+    font-style: italic; 
+    color: gray;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+}}
+
+\Css{.ecrm-0500:after {
+    content:" ";
+    white-space: pre;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+}}
+
+\begin{document}
+\EndPreamble

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -39,7 +39,11 @@
 \begin{document}
 
 \maketitle
+\ifdefined\HCode
+% turn off TOC
+\else
 \tableofcontents
+\fi
 
 \section{Introduction}
 \label{sec:introduction}


### PR DESCRIPTION
`make4ht` has a lot of defectors:
* When it parsing `lkmpg.tex` and meet `\tableofcontents` will throw error
* When it parsing `lkmpg.tex` and meet url with underscore `\_`, it will output `\_` 
directly instead of `_`
* TOC in generated page isn't as pretty as pdf version
* The `github action` script released by make4ht's team
worked inconsistent  with computer side which causing
error when generating `github page`,and I currently cannot 
find a way to generate `github
page` through `github action` via `make4ht`.
You can see the result page in [here](https://fennecj.github.io/lkmpg/html) currently.