### PR TITLE
WIP: Dockerized pdf build in Github Actions

### DIFF
--- a/.github/workflows/generate_pdf.yml
+++ b/.github/workflows/generate_pdf.yml
@@ -1,0 +1,23 @@
+name: build-deploy-assets
+
+on:
+  push:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: texlive/texlive
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: make all
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: lkmpg.pdf
+          tag_name: "latest"
+          prerelease: true


### PR DESCRIPTION
Build and release a pdf after every push to master using texlive/texlive docker image.
This PR is meant to be scope limited to serve as a foundation for #15 and #25.