### PR TITLE
Delete existing release asset before releasing

### DIFF
--- a/.github/workflows/generate_pdf.yml
+++ b/.github/workflows/generate_pdf.yml
@@ -15,6 +15,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: make all
+      - name: Delete old release asset
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ github.token }}
+          fail-if-no-assets: false
+          tag: latest
+          assets: lkmpg.pdf
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
We're using only one tag for release (`latest`), so we have to either replace it correctly or delete it before uploading, otherwise it will fail (https://github.com/ekangmonyet/lkmpg/runs/3213455232):
```
Error: Validation Failed: {"resource":"ReleaseAsset","code":"already_exists","field":"name"}
```
One possible solution is to use `mknejp/delete-release-assets` to delete existing asset.  If `action-gh-release` supports upserting (https://github.com/softprops/action-gh-release/pull/134), this should only be a **temporary** remedy.  Warning from the `delete-release-assets` repository:

> WARNING
Because this action has the power to delete any asset from any release in the repository (via the access token) be extra careful that you specify the correct tag!

Since it is not really urgent, we may wait for the patch for `action-gh-release` as well.