### PR TITLE
Publish GitHub Page with GitHub Action

### DIFF
--- a/.github/workflows/deploy_github_page.yaml
+++ b/.github/workflows/deploy_github_page.yaml
@@ -1,0 +1,24 @@
+name: build-deploy-github-page
+
+on:
+  push:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: twtug/lkmpg
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          make html
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./html
+          publish_branch: gh-pages

--- a/.github/workflows/generate_doc.yml
+++ b/.github/workflows/generate_doc.yml
@@ -9,22 +9,29 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: texlive/texlive
+    container: twtug/lkmpg
 
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: make all
+        run: |
+          make all
+          make html
+          tar zcvf lkmpg-html.tar.gz ./html
       - name: Delete old release asset
         uses: mknejp/delete-release-assets@v1
         with:
           token: ${{ github.token }}
           fail-if-no-assets: false
           tag: latest
-          assets: lkmpg.pdf
+          assets: |
+            lkmpg.pdf
+            lkmpg-html.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: lkmpg.pdf
+          files: |
+            lkmpg.pdf
+            lkmpg-html.tar.gz
           tag_name: "latest"
           prerelease: true


### PR DESCRIPTION
Use #20 `makefile` 
1. Generate the HTML assets and deploy them to the [GitHub Page](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)[1].
    * Here is the demo URL: https://focaaby.github.io/lkmpg/index.html
2. Publish the `html` directory as release HTML assets.
    * Demo download URL: https://github.com/focaaby/lkmpg/releases/download/latest/lkmpg-html.tar.gz

References:
1. https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site