### PR TITLE
Correspond the example output of hello-5.c

### DIFF
--- a/examples/hello-5.c
+++ b/examples/hello-5.c
@@ -13,7 +13,7 @@ static short int myshort = 1;
 static int myint = 420;
 static long int mylong = 9999;
 static char *mystring = "blah";
-static int myintArray[2] = {-1, -1};
+static int myintArray[2] = {420, 420};
 static int arr_argc = 0;
 
 /*

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -408,20 +408,24 @@ I would recommend playing around with this code:
 \begin{code}
 $ sudo insmod hello-5.ko mystring="bebop" myintArray=-1
 myshort is a short integer: 1
-myint is an integer: 20
+myint is an integer: 420
 mylong is a long integer: 9999
 mystring is a string: bebop
-myintArray is -1 and 420
+myintArray[0] = -1
+myintArray[1] = 420
+got 1 arguments for myintArray.
 
 $ sudo rmmod hello-5
 Goodbye, world 5
 
 $ sudo insmod hello-5.ko mystring="supercalifragilisticexpialidocious" myintArray=-1,-1
 myshort is a short integer: 1
-myint is an integer: 20
+myint is an integer: 420
 mylong is a long integer: 9999
 mystring is a string: supercalifragilisticexpialidocious
-myintArray is -1 and -1
+myintArray[0] = -1
+myintArray[1] = -1
+got 2 arguments for myintArray.
 
 $ sudo rmmod hello-5
 Goodbye, world 5


### PR DESCRIPTION
For the example module `hello_5`, the book shows the incorrect output which does not correspond to the example input. They are revised here in case to confuse the reader.

Note that I also change `myintArray[2] = {-1, -1}` to `myintArray[2] = {420, 420}`. I think it could make reader clearly reliaze how the command line arguments change the output from the example input.