### PR TITLE
Rewrite CSS to support scaling

### DIFF
--- a/html.cfg
+++ b/html.cfg
@@ -2,15 +2,31 @@
 
 \Configure{tableofcontents*}{chapter,section,subsection}
 
-\Css{* :not(img) {
-    max-width: 100\%;
-    width: 50vw; 
-    height: auto;
-    margin: 0 auto;
+\Css{html {
+    width: 100vw;
+    overflow-x: hidden;
 }}
 
-\Css{* {
-    font-size: 1vw;
+\Css{body {
+    max-width: 50rem;
+    box-sizing: border-box;
+    padding: 1rem;
+    margin: 0 auto;
+    overflow-x: hidden;
+}}
+
+\Css{div.author {
+    white-space: normal;
+}}
+
+\Css{img.math {
+    height: 1rem;
+    vertical-align: top;
+}}
+
+\Css{figure, .fancyvrb, .verbatim {
+    margin-inline: 0;
+    overflow-x: auto;
 }}
 
 \Css{.ecrm-0500 { 


### PR DESCRIPTION
This changes the layout to use the default font size with a reasonable
max width and margins around the body. Elements that would overflow on
narrow displays are changed to wrap (.author) or present a scroll bar as
necessary (figure, .verbatim, .fancyvrb). The properties on html and
body are set such that there is no full-document vertical scrolling.
Inline math is displayed in the same size as the surrounding text.