### PR TITLE
Temporary fix release action failed issue

### DIFF
--- a/.github/workflows/generate_doc.yaml
+++ b/.github/workflows/generate_doc.yaml
@@ -28,7 +28,7 @@ jobs:
             lkmpg.pdf
             lkmpg-html.tar.gz
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.8
         with:
           files: |
             lkmpg.pdf


### PR DESCRIPTION
According to softprops/action-gh-release#139
Currently the release action version we use has 
bug cause release failed. And we can turn to old
version to make things work again temporarily.
I have tried the latest version from `v0.1.10` to
`v0.1.7`, and `v0.1.8` is the newest version which
worked well when releasing files.