### PR TITLE
Add ` \cpp` and `\sh` syntax for inline code

### DIFF
--- a/lib/codeblock.tex
+++ b/lib/codeblock.tex
@@ -32,3 +32,6 @@
   breakafter=d,
   linenos
 }
+
+\newmintinline[sh]{bash}{}
+\newmintinline[cpp]{c}{}


### PR DESCRIPTION
Added a shorthand way to write inline code blocks.  `\cpp` is added for the inline C code (`\c` is taken - accent), and `\sh` is added for the inline bash code.