### PR TITLE
Provide detailed info for reference count.

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -894,14 +894,15 @@ The results of this would be impossible to predict, but they can not be very pos
 Normally, when you do not want to allow something, you return an error code (a negative number) from the function which is supposed to do it.
 With \cpp|cleanup_module| that's impossible because it is a void function.
 However, there is a counter which keeps track of how many processes are using your module.
-You can see what its value is by looking at the 3rd field of \verb|/proc/modules|.
+You can see what its value is by looking at the 3rd field with the command \sh|cat /proc/modules| or \sh|sudo lsmod|.
 If this number isn't zero, \sh|rmmod| will fail.
 Note that you do not have to check the counter from within \cpp|cleanup_module| because the check will be performed for you by the system call \cpp|sys_delete_module|, defined in \src{include/linux/syscalls.h}.
 You should not use this counter directly, but there are functions defined in \src{include/linux/module.h} which let you increase, decrease and display this counter:
 
 \begin{itemize}
-  \item \cpp|try_module_get(THIS_MODULE)|: Increment the use count.
-  \item \cpp|module_put(THIS_MODULE)|: Decrement the use count.
+  \item \cpp|try_module_get(THIS_MODULE)|: Increment the reference count of current module.
+  \item \cpp|module_put(THIS_MODULE)|: Decrement the reference count of current module.
+  \item \cpp|module_refcount(THIS_MODULE)|: Return the value of reference count of current module.
 \end{itemize}
 
 It is important to keep the counter accurate; if you ever do lose track of the correct usage count, you will never be able to unload the module; it's now reboot time, boys and girls.


### PR DESCRIPTION
This patch is intented to provide detailed info for reference count.

I add sudo lsmod command to provide an alternative way for user to check
the reference count for specific module.

I think `reference count` would be better compared to `use count` so I
replace `use count` with `reference count`.

The paragraph says "there are functions which let you increase,
decrease and display this counter".
But it didn't provide the function to display the the reference counter.
So I add description for module_refcount(THIS_MODULE) as the function
to display the the reference counter.