### PR TITLE
Update Archlinux kernel headers instructions

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -176,7 +176,7 @@ apt-cache search linux-headers-`uname -r`
 
 On Arch Linux:
 \begin{codebash}
-sudo pacman -S linux-libre-headers
+sudo pacman -S linux-headers
 \end{codebash}
 
 This will tell you what kernel header files are available.


### PR DESCRIPTION
`linux-libre-headers` has been moved to AUR [1]. We can simply install `linux-headers` [2] instead.

[1] https://aur.archlinux.org/packages/linux-libre-headers/
[2] https://archlinux.org/packages/core/x86_64/linux-headers/