### PR TITLE
Fix the warnings raised by Sparse

### DIFF
--- a/examples/bottomhalf.c
+++ b/examples/bottomhalf.c
@@ -45,7 +45,7 @@ static void bottomhalf_tasklet_fn(unsigned long data)
     pr_info("Bottom half tasklet ends\n");
 }
 
-DECLARE_TASKLET_OLD(buttontask, bottomhalf_tasklet_fn);
+static DECLARE_TASKLET_OLD(buttontask, bottomhalf_tasklet_fn);
 
 /* interrupt function triggered when a button is pressed */
 static irqreturn_t button_isr(int irq, void *data)

--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -16,8 +16,9 @@
 /*  Prototypes - this would normally go in a .h file */
 static int device_open(struct inode *, struct file *);
 static int device_release(struct inode *, struct file *);
-static ssize_t device_read(struct file *, char *, size_t, loff_t *);
-static ssize_t device_write(struct file *, const char *, size_t, loff_t *);
+static ssize_t device_read(struct file *, char __user *, size_t, loff_t *);
+static ssize_t device_write(struct file *, const char __user *, size_t,
+                            loff_t *);
 
 #define SUCCESS 0
 #define DEVICE_NAME "chardev" /* Dev name as it appears in /proc/devices   */
@@ -105,7 +106,7 @@ static int device_release(struct inode *inode, struct file *file)
  * read from it.
  */
 static ssize_t device_read(struct file *filp, /* see include/linux/fs.h   */
-                           char *buffer, /* buffer to fill with data */
+                           char __user *buffer, /* buffer to fill with data */
                            size_t length, /* length of the buffer     */
                            loff_t *offset)
 {
@@ -134,8 +135,8 @@ static ssize_t device_read(struct file *filp, /* see include/linux/fs.h   */
 }
 
 /* Called when a process writes to dev file: echo "hi" > /dev/hello */
-static ssize_t device_write(struct file *filp, const char *buff, size_t len,
-                            loff_t *off)
+static ssize_t device_write(struct file *filp, const char __user *buff,
+                            size_t len, loff_t *off)
 {
     pr_alert("Sorry, this operation is not supported.\n");
     return -EINVAL;

--- a/examples/completions.c
+++ b/examples/completions.c
@@ -61,7 +61,7 @@ ERROR_THREAD_1:
     return -1;
 }
 
-void completions_exit(void)
+static void completions_exit(void)
 {
     wait_for_completion(&machine.crank_comp);
     wait_for_completion(&machine.flywheel_comp);

--- a/examples/cryptosha256.c
+++ b/examples/cryptosha256.c
@@ -18,7 +18,7 @@ static void show_hash_result(char *plaintext, char *hash_sha256)
     pr_info("%s\n", str);
 }
 
-int cryptosha256_init(void)
+static int cryptosha256_init(void)
 {
     char *plaintext = "This is a test";
     char hash_sha256[SHA256_LENGTH];
@@ -53,7 +53,7 @@ int cryptosha256_init(void)
     return 0;
 }
 
-void cryptosha256_exit(void)
+static void cryptosha256_exit(void)
 {
 }
 

--- a/examples/cryptosk.c
+++ b/examples/cryptosk.c
@@ -171,7 +171,7 @@ out:
     return ret;
 }
 
-int cryptoapi_init(void)
+static int cryptoapi_init(void)
 {
     /* The world's favorite password */
     char *password = "password123";
@@ -186,7 +186,7 @@ int cryptoapi_init(void)
     return 0;
 }
 
-void cryptoapi_exit(void)
+static void cryptoapi_exit(void)
 {
     test_skcipher_finish(&sk);
 }

--- a/examples/example_mutex.c
+++ b/examples/example_mutex.c
@@ -6,7 +6,7 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 
-DEFINE_MUTEX(mymutex);
+static DEFINE_MUTEX(mymutex);
 
 static int example_mutex_init(void)
 {

--- a/examples/example_rwlock.c
+++ b/examples/example_rwlock.c
@@ -5,7 +5,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 
-DEFINE_RWLOCK(myrwlock);
+static DEFINE_RWLOCK(myrwlock);
 
 static void example_read_lock(void)
 {

--- a/examples/example_spinlock.c
+++ b/examples/example_spinlock.c
@@ -7,8 +7,8 @@
 #include <linux/module.h>
 #include <linux/spinlock.h>
 
-DEFINE_SPINLOCK(sl_static);
-spinlock_t sl_dynamic;
+static DEFINE_SPINLOCK(sl_static);
+static spinlock_t sl_dynamic;
 
 static void example_spinlock_static(void)
 {

--- a/examples/example_tasklet.c
+++ b/examples/example_tasklet.c
@@ -20,7 +20,7 @@ static void tasklet_fn(unsigned long data)
     pr_info("Example tasklet ends\n");
 }
 
-DECLARE_TASKLET_OLD(mytask, tasklet_fn);
+static DECLARE_TASKLET_OLD(mytask, tasklet_fn);
 
 static int example_tasklet_init(void)
 {

--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -86,8 +86,8 @@ done:
     return retval;
 }
 
-ssize_t test_ioctl_read(struct file *filp, char __user *buf, size_t count,
-                        loff_t *f_pos)
+static ssize_t test_ioctl_read(struct file *filp, char __user *buf,
+                               size_t count, loff_t *f_pos)
 {
     struct test_ioctl_data *ioctl_data = filp->private_data;
     unsigned char val;
@@ -139,7 +139,7 @@ static int test_ioctl_open(struct inode *inode, struct file *filp)
     return 0;
 }
 
-struct file_operations fops = {
+static struct file_operations fops = {
     .owner = THIS_MODULE,
     .open = test_ioctl_open,
     .release = test_ioctl_close,

--- a/examples/kbleds.c
+++ b/examples/kbleds.c
@@ -13,9 +13,9 @@
 
 MODULE_DESCRIPTION("Example module illustrating the use of Keyboard LEDs.");
 
-struct timer_list my_timer;
-struct tty_driver *my_driver;
-char kbledstatus = 0;
+static struct timer_list my_timer;
+static struct tty_driver *my_driver;
+static char kbledstatus = 0;
 
 #define BLINK_DELAY HZ / 5
 #define ALL_LEDS_ON 0x07

--- a/examples/procfs1.c
+++ b/examples/procfs1.c
@@ -14,10 +14,10 @@
 
 #define procfs_name "helloworld"
 
-struct proc_dir_entry *our_proc_file;
+static struct proc_dir_entry *our_proc_file;
 
-ssize_t procfile_read(struct file *filePointer, char *buffer,
-                      size_t buffer_length, loff_t *offset)
+static ssize_t procfile_read(struct file *filePointer, char __user *buffer,
+                             size_t buffer_length, loff_t *offset)
 {
     char s[13] = "HelloWorld!\n";
     int len = sizeof(s);

--- a/examples/procfs2.c
+++ b/examples/procfs2.c
@@ -25,8 +25,8 @@ static char procfs_buffer[PROCFS_MAX_SIZE];
 static unsigned long procfs_buffer_size = 0;
 
 /* This function is called then the /proc file is read */
-ssize_t procfile_read(struct file *filePointer, char *buffer,
-                      size_t buffer_length, loff_t *offset)
+static ssize_t procfile_read(struct file *filePointer, char __user *buffer,
+                             size_t buffer_length, loff_t *offset)
 {
     char s[13] = "HelloWorld!\n";
     int len = sizeof(s);
@@ -44,8 +44,8 @@ ssize_t procfile_read(struct file *filePointer, char *buffer,
 }
 
 /* This function is called with the /proc file is written. */
-static ssize_t procfile_write(struct file *file, const char *buff, size_t len,
-                              loff_t *off)
+static ssize_t procfile_write(struct file *file, const char __user *buff,
+                              size_t len, loff_t *off)
 {
     procfs_buffer_size = len;
     if (procfs_buffer_size > PROCFS_MAX_SIZE)

--- a/examples/procfs3.c
+++ b/examples/procfs3.c
@@ -16,12 +16,12 @@
 #define PROCFS_MAX_SIZE 2048
 #define PROCFS_ENTRY_FILENAME "buffer2k"
 
-struct proc_dir_entry *our_proc_file;
+static struct proc_dir_entry *our_proc_file;
 static char procfs_buffer[PROCFS_MAX_SIZE];
 static unsigned long procfs_buffer_size = 0;
 
-static ssize_t procfs_read(struct file *filp, char *buffer, size_t length,
-                           loff_t *offset)
+static ssize_t procfs_read(struct file *filp, char __user *buffer,
+                           size_t length, loff_t *offset)
 {
     static int finished = 0;
 
@@ -38,8 +38,8 @@ static ssize_t procfs_read(struct file *filp, char *buffer, size_t length,
     pr_debug("procfs_read: read %lu bytes\n", procfs_buffer_size);
     return procfs_buffer_size;
 }
-static ssize_t procfs_write(struct file *file, const char *buffer, size_t len,
-                            loff_t *off)
+static ssize_t procfs_write(struct file *file, const char __user *buffer,
+                            size_t len, loff_t *off)
 {
     if (len > PROCFS_MAX_SIZE)
         procfs_buffer_size = PROCFS_MAX_SIZE;
@@ -51,12 +51,12 @@ static ssize_t procfs_write(struct file *file, const char *buffer, size_t len,
     pr_debug("procfs_write: write %lu bytes\n", procfs_buffer_size);
     return procfs_buffer_size;
 }
-int procfs_open(struct inode *inode, struct file *file)
+static int procfs_open(struct inode *inode, struct file *file)
 {
     try_module_get(THIS_MODULE);
     return 0;
 }
-int procfs_close(struct inode *inode, struct file *file)
+static int procfs_close(struct inode *inode, struct file *file)
 {
     module_put(THIS_MODULE);
     return 0;

--- a/examples/sleep.c
+++ b/examples/sleep.c
@@ -29,7 +29,7 @@ static struct proc_dir_entry *our_proc_file;
  * function.
  */
 static ssize_t module_output(struct file *file, /* see include/linux/fs.h   */
-                             char *buf, /* The buffer to put data to
+                             char __user *buf, /* The buffer to put data to
                                                    (in the user segment)    */
                              size_t len, /* The length of the buffer */
                              loff_t *offset)
@@ -58,7 +58,7 @@ static ssize_t module_output(struct file *file, /* see include/linux/fs.h   */
  * /proc file.
  */
 static ssize_t module_input(struct file *file, /* The file itself */
-                            const char *buf, /* The buffer with input */
+                            const char __user *buf, /* The buffer with input */
                             size_t length, /* The buffer's length */
                             loff_t *offset) /* offset to file - ignore */
 {
@@ -77,10 +77,10 @@ static ssize_t module_input(struct file *file, /* The file itself */
 }
 
 /* 1 if the file is currently open by somebody */
-int already_open = 0;
+static int already_open = 0;
 
 /* Queue of processes who want our file */
-DECLARE_WAIT_QUEUE_HEAD(waitq);
+static DECLARE_WAIT_QUEUE_HEAD(waitq);
 
 /* Called when the /proc file is opened */
 static int module_open(struct inode *inode, struct file *file)
@@ -141,7 +141,7 @@ static int module_open(struct inode *inode, struct file *file)
 }
 
 /* Called when the /proc file is closed */
-int module_close(struct inode *inode, struct file *file)
+static int module_close(struct inode *inode, struct file *file)
 {
     /* Set already_open to zero, so one of the processes in the waitq will
      * be able to set already_open back to one and to open the file. All

--- a/examples/stop.c
+++ b/examples/stop.c
@@ -5,7 +5,7 @@
 #include <linux/kernel.h> /* We are doing kernel work */
 #include <linux/module.h> /* Specifically, a module  */
 
-void cleanup_module()
+void cleanup_module(void)
 {
     pr_info("Short is the life of a kernel module\n");
 }

--- a/examples/syscall.c
+++ b/examples/syscall.c
@@ -59,7 +59,7 @@ module_param(sym, ulong, 0644);
 
 #endif /* Version < v5.7 */
 
-unsigned long **sys_call_table;
+static unsigned long **sys_call_table;
 
 /* UID we want to spy on - will be filled from the command line. */
 static int uid;
@@ -75,7 +75,7 @@ module_param(uid, int, 0644);
  * Another reason for this is that we can not get sys_open.
  * It is a static variable, so it is not exported.
  */
-asmlinkage int (*original_call)(const char *, int, int);
+static asmlinkage int (*original_call)(const char *, int, int);
 
 /* The function we will replace sys_open (the function called when you
  * call the open system call) with. To find the exact prototype, with
@@ -87,7 +87,7 @@ asmlinkage int (*original_call)(const char *, int, int);
  * wreck havoc and require programs to be recompiled, since the system
  * calls are the interface between the kernel and the processes).
  */
-asmlinkage int our_sys_open(const char *filename, int flags, int mode)
+static asmlinkage int our_sys_open(const char *filename, int flags, int mode)
 {
     int i = 0;
     char ch;
@@ -95,7 +95,7 @@ asmlinkage int our_sys_open(const char *filename, int flags, int mode)
     /* Report the file, if relevant */
     pr_info("Opened file by %d: ", uid);
     do {
-        get_user(ch, filename + i);
+        get_user(ch, (char __user *)filename + i);
         i++;
         pr_info("%c", ch);
     } while (ch != 0);


### PR DESCRIPTION
Sparse is a semantic parser of C language.
It can be used to find out the potential
problems of kernel code.

* https://www.kernel.org/doc/html/latest/dev-tools/sparse.html

The warnings:
```shell
$ make C=2
make -C /lib/modules/5.11.0-27-generic/build M=/lkmpg/examples modules
make[1]: Entering directory '/usr/src/linux-headers-5.11.0-27-generic'
  CC [M]  /lkmpg/examples/hello-1.o
  CHECK   /lkmpg/examples/hello-1.c
  CC [M]  /lkmpg/examples/hello-2.o
  CHECK   /lkmpg/examples/hello-2.c
  CC [M]  /lkmpg/examples/hello-3.o
  CHECK   /lkmpg/examples/hello-3.c
  CC [M]  /lkmpg/examples/hello-4.o
  CHECK   /lkmpg/examples/hello-4.c
  CC [M]  /lkmpg/examples/hello-5.o
  CHECK   /lkmpg/examples/hello-5.c
  CC [M]  /lkmpg/examples/start.o
  CHECK   /lkmpg/examples/start.c
  CC [M]  /lkmpg/examples/stop.o
  CHECK   /lkmpg/examples/stop.c
/lkmpg/examples/stop.c:8:21: warning: non-ANSI function declaration of function 'cleanup_module'
  CC [M]  /lkmpg/examples/chardev.o
  CHECK   /lkmpg/examples/chardev.c
/lkmpg/examples/chardev.c:126:9: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/chardev.c:126:9:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/chardev.c:126:9:    got char *
/lkmpg/examples/chardev.c:126:9: warning: incorrect type in assignment (different address spaces)
/lkmpg/examples/chardev.c:126:9:    expected void [noderef] __user *__ptr_pu
/lkmpg/examples/chardev.c:126:9:    got char *
/lkmpg/examples/chardev.c:37:13: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/chardev.c:37:13:    expected long ( *read )( ... )
/lkmpg/examples/chardev.c:37:13:    got long ( * )( ... )
/lkmpg/examples/chardev.c:38:14: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/chardev.c:38:14:    expected long ( *write )( ... )
/lkmpg/examples/chardev.c:38:14:    got long ( * )( ... )
  CC [M]  /lkmpg/examples/procfs1.o
  CHECK   /lkmpg/examples/procfs1.c
/lkmpg/examples/procfs1.c:17:23: warning: symbol 'our_proc_file' was not declared. Should it be static?
/lkmpg/examples/procfs1.c:26:40: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/procfs1.c:26:40:    expected void [noderef] __user *to
/lkmpg/examples/procfs1.c:26:40:    got char *buffer
/lkmpg/examples/procfs1.c:19:9: warning: symbol 'procfile_read' was not declared. Should it be static?
/lkmpg/examples/procfs1.c:39:18: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/procfs1.c:39:18:    expected long ( *proc_read )( ... )
/lkmpg/examples/procfs1.c:39:18:    got long ( * )( ... )
  CC [M]  /lkmpg/examples/procfs2.o
  CHECK   /lkmpg/examples/procfs2.c
/lkmpg/examples/procfs2.c:35:40: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/procfs2.c:35:40:    expected void [noderef] __user *to
/lkmpg/examples/procfs2.c:35:40:    got char *buffer
/lkmpg/examples/procfs2.c:28:9: warning: symbol 'procfile_read' was not declared. Should it be static?
/lkmpg/examples/procfs2.c:54:39: warning: incorrect type in argument 2 (different address spaces)
/lkmpg/examples/procfs2.c:54:39:    expected void const [noderef] __user *from
/lkmpg/examples/procfs2.c:54:39:    got char const *buff
/lkmpg/examples/procfs2.c:63:18: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/procfs2.c:63:18:    expected long ( *proc_read )( ... )
/lkmpg/examples/procfs2.c:63:18:    got long ( * )( ... )
/lkmpg/examples/procfs2.c:64:19: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/procfs2.c:64:19:    expected long ( *proc_write )( ... )
/lkmpg/examples/procfs2.c:64:19:    got long ( * )( ... )
  CC [M]  /lkmpg/examples/procfs3.o
  CHECK   /lkmpg/examples/procfs3.c
/lkmpg/examples/procfs3.c:19:23: warning: symbol 'our_proc_file' was not declared. Should it be static?
/lkmpg/examples/procfs3.c:35:22: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/procfs3.c:35:22:    expected void [noderef] __user *to
/lkmpg/examples/procfs3.c:35:22:    got char *buffer
/lkmpg/examples/procfs3.c:48:39: warning: incorrect type in argument 2 (different address spaces)
/lkmpg/examples/procfs3.c:48:39:    expected void const [noderef] __user *from
/lkmpg/examples/procfs3.c:48:39:    got char const *buffer
/lkmpg/examples/procfs3.c:54:5: warning: symbol 'procfs_open' was not declared. Should it be static?
/lkmpg/examples/procfs3.c:59:5: warning: symbol 'procfs_close' was not declared. Should it be static?
/lkmpg/examples/procfs3.c:67:18: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/procfs3.c:67:18:    expected long ( *proc_read )( ... )
/lkmpg/examples/procfs3.c:67:18:    got long ( * )( ... )
/lkmpg/examples/procfs3.c:68:19: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/procfs3.c:68:19:    expected long ( *proc_write )( ... )
/lkmpg/examples/procfs3.c:68:19:    got long ( * )( ... )
  CC [M]  /lkmpg/examples/procfs4.o
  CHECK   /lkmpg/examples/procfs4.c
  CC [M]  /lkmpg/examples/hello-sysfs.o
  CHECK   /lkmpg/examples/hello-sysfs.c
  CC [M]  /lkmpg/examples/sleep.o
  CHECK   /lkmpg/examples/sleep.c
/lkmpg/examples/sleep.c:51:9: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/sleep.c:51:9:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/sleep.c:51:9:    got char *
/lkmpg/examples/sleep.c:51:9: warning: incorrect type in assignment (different address spaces)
/lkmpg/examples/sleep.c:51:9:    expected void [noderef] __user *__ptr_pu
/lkmpg/examples/sleep.c:51:9:    got char *
/lkmpg/examples/sleep.c:71:9: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/sleep.c:71:9:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/sleep.c:71:9:    got char const *
/lkmpg/examples/sleep.c:80:5: warning: symbol 'already_open' was not declared. Should it be static?
/lkmpg/examples/sleep.c:83:1: warning: symbol 'waitq' was not declared. Should it be static?
/lkmpg/examples/sleep.c:144:5: warning: symbol 'module_close' was not declared. Should it be static?
/lkmpg/examples/sleep.c:173:18: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/sleep.c:173:18:    expected long ( *proc_read )( ... )
/lkmpg/examples/sleep.c:173:18:    got long ( * )( ... )
/lkmpg/examples/sleep.c:174:19: warning: incorrect type in initializer (incompatible argument 2 (different address spaces))
/lkmpg/examples/sleep.c:174:19:    expected long ( *proc_write )( ... )
/lkmpg/examples/sleep.c:174:19:    got long ( * )( ... )
  CC [M]  /lkmpg/examples/print_string.o
  CHECK   /lkmpg/examples/print_string.c
  CC [M]  /lkmpg/examples/kbleds.o
  CHECK   /lkmpg/examples/kbleds.c
/lkmpg/examples/kbleds.c:16:19: warning: symbol 'my_timer' was not declared. Should it be static?
/lkmpg/examples/kbleds.c:17:19: warning: symbol 'my_driver' was not declared. Should it be static?
/lkmpg/examples/kbleds.c:18:6: warning: symbol 'kbledstatus' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/sched.o
  CHECK   /lkmpg/examples/sched.c
  CC [M]  /lkmpg/examples/chardev2.o
  CHECK   /lkmpg/examples/chardev2.c
/lkmpg/examples/chardev2.c:142:9: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/chardev2.c:142:9:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/chardev2.c:142:9:    got char *[assigned] temp
/lkmpg/examples/chardev2.c:144:13: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/chardev2.c:144:13:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/chardev2.c:144:13:    got char *[assigned] temp
/lkmpg/examples/chardev2.c:146:29: warning: incorrect type in argument 2 (different address spaces)
/lkmpg/examples/chardev2.c:146:29:    expected char const [noderef] __user *buffer
/lkmpg/examples/chardev2.c:146:29:    got char *
/lkmpg/examples/chardev2.c:146:52: warning: Using plain integer as NULL pointer
/lkmpg/examples/chardev2.c:153:32: warning: incorrect type in argument 2 (different address spaces)
/lkmpg/examples/chardev2.c:153:32:    expected char [noderef] __user *[assigned] buffer
/lkmpg/examples/chardev2.c:153:32:    got char *
/lkmpg/examples/chardev2.c:153:56: warning: Using plain integer as NULL pointer
/lkmpg/examples/chardev2.c:158:9: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/chardev2.c:158:9:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/chardev2.c:158:9:    got char *
/lkmpg/examples/chardev2.c:158:9: warning: incorrect type in assignment (different address spaces)
/lkmpg/examples/chardev2.c:158:9:    expected void [noderef] __user *__ptr_pu
/lkmpg/examples/chardev2.c:158:9:    got char *
/lkmpg/examples/chardev2.c:124:6: warning: symbol 'device_ioctl' was not declared. Should it be static?
/lkmpg/examples/chardev2.c:179:24: warning: symbol 'fops' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/syscall.o
  CHECK   /lkmpg/examples/syscall.c
/lkmpg/examples/syscall.c:62:15: warning: symbol 'sys_call_table' was not declared. Should it be static?
/lkmpg/examples/syscall.c:78:16: warning: symbol 'original_call' was not declared. Should it be static?
/lkmpg/examples/syscall.c:98:9: warning: incorrect type in argument 1 (different address spaces)
/lkmpg/examples/syscall.c:98:9:    expected void const volatile [noderef] __user *ptr
/lkmpg/examples/syscall.c:98:9:    got char const *
/lkmpg/examples/syscall.c:90:16: warning: symbol 'our_sys_open' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/intrpt.o
  CHECK   /lkmpg/examples/intrpt.c
  CC [M]  /lkmpg/examples/cryptosha256.o
  CHECK   /lkmpg/examples/cryptosha256.c
/lkmpg/examples/cryptosha256.c:21:5: warning: symbol 'cryptosha256_init' was not declared. Should it be static?
/lkmpg/examples/cryptosha256.c:56:6: warning: symbol 'cryptosha256_exit' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/cryptosk.o
  CHECK   /lkmpg/examples/cryptosk.c
/lkmpg/examples/cryptosk.c:174:5: warning: symbol 'cryptoapi_init' was not declared. Should it be static?
/lkmpg/examples/cryptosk.c:189:6: warning: symbol 'cryptoapi_exit' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/completions.o
  CHECK   /lkmpg/examples/completions.c
/lkmpg/examples/completions.c:64:6: warning: symbol 'completions_exit' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/example_tasklet.o
  CHECK   /lkmpg/examples/example_tasklet.c
/lkmpg/examples/example_tasklet.c:23:1: warning: symbol 'mytask' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/devicemodel.o
  CHECK   /lkmpg/examples/devicemodel.c
  CC [M]  /lkmpg/examples/example_spinlock.o
  CHECK   /lkmpg/examples/example_spinlock.c
/lkmpg/examples/example_spinlock.c:10:1: warning: symbol 'sl_static' was not declared. Should it be static?
/lkmpg/examples/example_spinlock.c:11:12: warning: symbol 'sl_dynamic' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/example_rwlock.o
  CHECK   /lkmpg/examples/example_rwlock.c
/lkmpg/examples/example_rwlock.c:8:1: warning: symbol 'myrwlock' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/example_atomic.o
  CHECK   /lkmpg/examples/example_atomic.c
  CC [M]  /lkmpg/examples/example_mutex.o
  CHECK   /lkmpg/examples/example_mutex.c
/lkmpg/examples/example_mutex.c:9:1: warning: symbol 'mymutex' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/bottomhalf.o
  CHECK   /lkmpg/examples/bottomhalf.c
/lkmpg/examples/bottomhalf.c:48:1: warning: symbol 'buttontask' was not declared. Should it be static?
  CC [M]  /lkmpg/examples/ioctl.o
  CHECK   /lkmpg/examples/ioctl.c
/lkmpg/examples/ioctl.c:89:9: warning: symbol 'test_ioctl_read' was not declared. Should it be static?
/lkmpg/examples/ioctl.c:142:24: warning: symbol 'fops' was not declared. Should it be static?
```