### PR TITLE
Improve readability

### DIFF
--- a/html.cfg
+++ b/html.cfg
@@ -8,11 +8,26 @@
 }}
 
 \Css{body {
-    max-width: 50rem;
+    max-width: 55rem;
     box-sizing: border-box;
     padding: 1rem;
     margin: 0 auto;
     overflow-x: hidden;
+    background-color: #F4ECD8;
+    color: #5B464B;
+    line-height: 1.5;
+}}
+
+\Css{a {
+color: #0060DF;
+}}
+
+\Css{p, a {
+font-size: 1.2em;
+}}
+
+\Css{p + pre {
+font-size: 1.1em;
 }}
 
 \Css{div.author {

--- a/html.cfg
+++ b/html.cfg
@@ -13,13 +13,13 @@
     padding: 1rem;
     margin: 0 auto;
     overflow-x: hidden;
-    background-color: #F4ECD8;
-    color: #5B464B;
+    background-color: \#F4ECD8;
+    color: \#5B464B;
     line-height: 1.5;
 }}
 
 \Css{a {
-color: #0060DF;
+color: \#0060DF;
 }}
 
 \Css{p, a {


### PR DESCRIPTION
Related issue #82 

This new foreground + background color maintains the minimum of 7:1 contrast ratio as specified by WCAG (this has 7.36:1) and is the same colors firefox reading mode uses when choosing the sepia theme. 

Fonts are too small by default, using responsive units (em) let's me increase them, I am unsure where or if there is font-size specified for parent anywhere but it seems to have been manually decreased.

Increased max-width slightly to adjust for new size and more standard line-height, so the doc doesn't feel significantly longer, still maintains good eye travel.