### PR TITLE
Work around inconsistent text scaling

### DIFF
--- a/html.cfg
+++ b/html.cfg
@@ -23,7 +23,7 @@ color: \#0060DF;
 }}
 
 \Css{p, a {
-font-size: 1.2em;
+font-size: 1.2rem;
 }}
 
 \Css{p + pre {


### PR DESCRIPTION
p + pre remains at em as we want to use the parent element here (however rem could be used too, just requires a bigger value). I am setting it to 110% size otherwise some codeblocks have relatively small text. The smaller codeblocks do appear bigger but I do not think that they are TOO big, let me know what you think. This is unchanged from before this commit.