### PR TITLE
Remove kbleds from non-working list

### DIFF
--- a/.ci/non-working
+++ b/.ci/non-working
@@ -1,3 +1,2 @@
 bottomhalf
 intrpt
-kbleds


### PR DESCRIPTION
Since #98 has fixed the error with kbleds caused by changed timer API,
now it can work again with docker container.