### PR TITLE
Add lighter Dockerfile to build those html and pdf in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM twtug/lkmpg as builder
+LABEL MAINTAINER="25077667"
+
+COPY . /workdir
+
+RUN make all && \
+	make html && \
+	rm -f *.dvi *.aux *.log *.ps *.out lkmpg.bbl lkmpg.blg lkmpg.lof lkmpg.toc
+
+FROM alpine
+WORKDIR /workdir
+
+COPY --from=builder /workdir/lkmpg.pdf /workdir
+COPY --from=builder /workdir/html /workdir
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,3 @@ WORKDIR /workdir
 
 COPY --from=builder /workdir/lkmpg.pdf /workdir
 COPY --from=builder /workdir/html /workdir
-


### PR DESCRIPTION
The original docker image will generate lots of middles-files that are owned by the root.
Alternatively, we can copy those "HTML"s and "PDF" from the image which is built from this Dockerfile directly.
By these commands:
```
id=$(docker create <IMAGE_NAME>)
docker cp $id:/workdir .   
docker rm -v $id
```

This image is much lighter and has zero side-effect.