### PR TITLE
ioctl.c: Remove unnecessary initialization

### DIFF
--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -149,7 +149,7 @@ static struct file_operations fops = {
 
 static int ioctl_init(void)
 {
-    dev_t dev = MKDEV(test_ioctl_major, 0);
+    dev_t dev;
     int alloc_ret = 0;
     int cdev_ret = 0;
     alloc_ret = alloc_chrdev_region(&dev, 0, num_of_dev, DRIVER_NAME);


### PR DESCRIPTION
The "alloc_chrdev_region" function will dynamically choose the
major number and store it at "dev". It is unnecessary to initialize
the "dev" before the "alloc_chrdev_region" function.