### PR TITLE
CI: Add Cppcheck to verify the code

### DIFF
--- a/.ci/static-analysis.sh
+++ b/.ci/static-analysis.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|cc|c|h)\$")
+
+CPPCHECK=$(which cppcheck)
+if [ $? -ne 0 ]; then
+    echo "[!] cppcheck not installed. Failed to run static analysis the source code." >&2
+    exit 1
+fi
+
+## Suppression list ##
+# This list will explain the detail of suppressed warnings.
+# The prototype of the item should be like:
+# "- [{file}] {spec}: {reason}"
+#
+# - [hello-1.c] unusedFunction: False positive of init_module and cleanup_module.
+# - [*.c] missingIncludeSystem: Focus on the example code, not the kernel headers.
+
+OPTS="  --enable=warning,style,performance,information
+        --suppress=unusedFunction:hello-1.c
+        --suppress=missingIncludeSystem
+        --std=c89 "
+
+$CPPCHECK $OPTS --xml ${SOURCES} 2> cppcheck.xml
+ERROR_COUNT=$(cat cppcheck.xml | egrep -c "</error>" )
+
+if [ $ERROR_COUNT -gt 0 ]; then
+    echo "Cppcheck failed: error count is $ERROR_COUNT"
+    cat cppcheck.xml
+    exit 1
+fi
+exit 0

--- a/.github/workflows/generate_doc.yaml
+++ b/.github/workflows/generate_doc.yaml
@@ -44,6 +44,8 @@ jobs:
       - name: validate coding style and functionality
         run: |
             sudo apt-get install -q -y clang-format-11
+            sudo apt-get install -q -y cppcheck
             .ci/check-format.sh
+            .ci/static-analysis.sh
             .ci/build-n-run.sh
         shell: bash

--- a/examples/example_atomic.c
+++ b/examples/example_atomic.c
@@ -7,10 +7,10 @@
 
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
 #define BYTE_TO_BINARY(byte)                                                   \
-    (byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'),                      \
-        (byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'),                  \
-        (byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'),                  \
-        (byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0')
+    ((byte & 0x80) ? '1' : '0'), ((byte & 0x40) ? '1' : '0'),                  \
+        ((byte & 0x20) ? '1' : '0'), ((byte & 0x10) ? '1' : '0'),              \
+        ((byte & 0x08) ? '1' : '0'), ((byte & 0x04) ? '1' : '0'),              \
+        ((byte & 0x02) ? '1' : '0'), ((byte & 0x01) ? '1' : '0')
 
 static void atomic_add_subtract(void)
 {

--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -10,7 +10,6 @@
 #include <linux/uaccess.h>
 
 struct ioctl_arg {
-    unsigned int reg;
     unsigned int val;
 };
 


### PR DESCRIPTION
Use Cppcheck[1], the static analysis tool, to verify the example codes.
Since Cppcheck has the false-positive and we have to suppress those
warnings sometimes. So, we have to provide the list to display the
suppressed warning for the clarity of maintenance.

[1] https://cppcheck.sourceforge.io/

- sysprog21/lkmpg: : https://github.com/sysprog21/lkmpg/issues/99