### PR TITLE
Fixed parameter name for hello-5.

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -411,26 +411,26 @@ It takes two parameters: a variable name and a free form string describing that 
 
 I would recommend playing around with this code:
 \begin{code}
-$ sudo insmod hello-5.ko mystring="bebop" myintArray=-1
+$ sudo insmod hello-5.ko mystring="bebop" myintarray=-1
 myshort is a short integer: 1
 myint is an integer: 420
 mylong is a long integer: 9999
 mystring is a string: bebop
-myintArray[0] = -1
-myintArray[1] = 420
-got 1 arguments for myintArray.
+myintarray[0] = -1
+myintarray[1] = 420
+got 1 arguments for myintarray.
 
 $ sudo rmmod hello-5
 Goodbye, world 5
 
-$ sudo insmod hello-5.ko mystring="supercalifragilisticexpialidocious" myintArray=-1,-1
+$ sudo insmod hello-5.ko mystring="supercalifragilisticexpialidocious" myintarray=-1,-1
 myshort is a short integer: 1
 myint is an integer: 420
 mylong is a long integer: 9999
 mystring is a string: supercalifragilisticexpialidocious
-myintArray[0] = -1
-myintArray[1] = -1
-got 2 arguments for myintArray.
+myintarray[0] = -1
+myintarray[1] = -1
+got 2 arguments for myintarray.
 
 $ sudo rmmod hello-5
 Goodbye, world 5


### PR DESCRIPTION
Parameters are case-sensitive, so `myintArray` is different from `myintarray`, and people who are running the example with copy/paste will find it doesn't work as described in the text.  It is all lower-case in the code, so adjusted the example runs to match.