### PR TITLE
Add the description about some file ops and fix several problems

### DIFF
--- a/examples/chardev2.c
+++ b/examples/chardev2.c
@@ -17,18 +17,18 @@
 #define DEVICE_NAME "char_dev"
 #define BUF_LEN 80
 
+enum {
+    CDEV_NOT_USED = 0,
+    CDEV_EXCLUSIVE_OPEN = 1,
+};
+
 /* Is the device open right now? Used to prevent concurrent access into
  * the same device
  */
-static atomic_t already_open = ATOMIC_INIT(0);
+static atomic_t already_open = ATOMIC_INIT(CDEV_NOT_USED);
 
 /* The message the device will give when asked */
 static char message[BUF_LEN];
-
-/* How far did the process reading the message get? Useful if the message
- * is larger than the size of the buffer we get to fill in device_read.
- */
-static char *message_ptr;
 
 static struct class *cls;
 
@@ -38,11 +38,9 @@ static int device_open(struct inode *inode, struct file *file)
     pr_info("device_open(%p)\n", file);
 
     /* We don't want to talk to two processes at the same time. */
-    if (atomic_cmpxchg(&already_open, 0, 1))
+    if (atomic_cmpxchg(&already_open, CDEV_NOT_USED, CDEV_EXCLUSIVE_OPEN))
         return -EBUSY;
 
-    /* Initialize the message */
-    message_ptr = message;
     try_module_get(THIS_MODULE);
     return SUCCESS;
 }
@@ -52,7 +50,7 @@ static int device_release(struct inode *inode, struct file *file)
     pr_info("device_release(%p,%p)\n", inode, file);
 
     /* We're now ready for our next caller */
-    atomic_set(&already_open, 0);
+    atomic_set(&already_open, CDEV_NOT_USED);
 
     module_put(THIS_MODULE);
     return SUCCESS;
@@ -68,12 +66,17 @@ static ssize_t device_read(struct file *file, /* see include/linux/fs.h   */
 {
     /* Number of bytes actually written to the buffer */
     int bytes_read = 0;
+    /* How far did the process reading the message get? Useful if the message
+     * is larger than the size of the buffer we get to fill in device_read.
+     */
+    const char *message_ptr = message;
 
-    pr_info("device_read(%p,%p,%ld)\n", file, buffer, length);
+    if (!*(message_ptr + *offset)) { /* we are at the end of message */
+        *offset = 0; /* reset the offset */
+        return 0; /* signify end of file */
+    }
 
-    /* If at the end of message, return 0 (which signifies end of file). */
-    if (*message_ptr == 0)
-        return 0;
+    message_ptr += *offset;
 
     /* Actually put the data into the buffer */
     while (length && *message_ptr) {
@@ -89,6 +92,8 @@ static ssize_t device_read(struct file *file, /* see include/linux/fs.h   */
 
     pr_info("Read %d bytes, %ld left\n", bytes_read, length);
 
+    *offset += bytes_read;
+
     /* Read functions are supposed to return the number of bytes actually
      * inserted into the buffer.
      */
@@ -101,12 +106,10 @@ static ssize_t device_write(struct file *file, const char __user *buffer,
 {
     int i;
 
-    pr_info("device_write(%p,%s,%ld)", file, buffer, length);
+    pr_info("device_write(%p,%p,%ld)", file, buffer, length);
 
     for (i = 0; i < length && i < BUF_LEN; i++)
         get_user(message[i], buffer + i);
-
-    message_ptr = message;
 
     /* Again, return the number of input characters used. */
     return i;
@@ -126,43 +129,44 @@ device_ioctl(struct file *file, /* ditto */
              unsigned long ioctl_param)
 {
     int i;
-    char *temp;
-    char ch;
 
     /* Switch according to the ioctl called */
     switch (ioctl_num) {
-    case IOCTL_SET_MSG:
+    case IOCTL_SET_MSG: {
         /* Receive a pointer to a message (in user space) and set that to
-         * be the device's message.  Get the parameter given to ioctl by
+         * be the device's message. Get the parameter given to ioctl by
          * the process.
          */
-        temp = (char *)ioctl_param;
+        char __user *tmp = (char __user *)ioctl_param;
+        char ch;
 
         /* Find the length of the message */
-        get_user(ch, (char __user *)temp);
-        for (i = 0; ch && i < BUF_LEN; i++, temp++)
-            get_user(ch, (char __user *)temp);
+        get_user(ch, tmp);
+        for (i = 0; ch && i < BUF_LEN; i++, tmp++)
+            get_user(ch, tmp);
 
         device_write(file, (char __user *)ioctl_param, i, NULL);
         break;
+    }
+    case IOCTL_GET_MSG: {
+        loff_t offset = 0;
 
-    case IOCTL_GET_MSG:
         /* Give the current message to the calling process - the parameter
          * we got is a pointer, fill it.
          */
-        i = device_read(file, (char __user *)ioctl_param, 99, NULL);
+        i = device_read(file, (char __user *)ioctl_param, 99, &offset);
 
         /* Put a zero at the end of the buffer, so it will be properly
          * terminated.
          */
         put_user('\0', (char __user *)ioctl_param + i);
         break;
-
+    }
     case IOCTL_GET_NTH_BYTE:
         /* This ioctl is both input (ioctl_param) and output (the return
          * value of this function).
          */
-        return message[ioctl_param];
+        return (long)message[ioctl_param];
         break;
     }
 

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -835,6 +835,9 @@ The meaning is clear, and you should be aware that any member of the structure w
 
 An instance of \cpp|struct file_operations| containing pointers to functions that are used to implement \cpp|read|, \cpp|write|, \cpp|open|, \ldots{} system calls is commonly named \cpp|fops|.
 
+Since Linux v3.14, the read, write and seek operations are guaranteed for thread-safe by using the \cpp|f_pos| specific lock, which makes the file position update to become the mutual exclusion.
+So, we can safely implement those operations without unnecessary locking.
+
 Since Linux v5.6, the \cpp|proc_ops| structure was introduced to replace the use of the \cpp|file_operations| structure when registering proc handlers.
 
 \subsection{The file structure}
@@ -927,8 +930,8 @@ We simply read in the data and print a message acknowledging that we received it
 In the multiple-threaded environment, without any protection, concurrent access to the same memory may lead to the race condition, and will not preserve the performance.
 In the kernel module, this problem may happen due to multiple instances accessing the shared resources.
 Therefore, a solution is to enforce the exclusive access.
-We use atomic Compare-And-Swap (CAS), the single atomic operation, to determine whether the file is currently open by someone.
-CAS compares the contents of a memory loaction with the expected value and, only if they are the same, modifies the contents of that memory location to the desired value.
+We use atomic Compare-And-Swap (CAS) to maintain the states, \cpp|CDEV_NOT_USED| and \cpp|CDEV_EXCLUSIVE_OPEN|, to determine whether the file is currently opened by someone or not.
+CAS compares the contents of a memory location with the expected value and, only if they are the same, modifies the contents of that memory location to the desired value.
 See more concurrency details in the \ref{sec:synchronization} section.
 
 \samplec{examples/chardev.c}


### PR DESCRIPTION
Even though the concurrent access to the module has been fixed at commit 148fb01,
the function of device operations can be called concurrently.

In chardev2.c, the message buffer can be simultaneously accessed by the read and
write operations. It can solve by allowing only one of the operations to work at
the time.
In chardev.c, the msg_ptr is the global variable. Therefore, when someone is
concurrently using the read operation will lead to a data race.
The pointer can change into the local variable of the read operation. So, each
read operation will not use the same pointer at the same time.

---
Edited:

Since Linux v3.14, the read, write and seek operations of struct files are
guaranteed for thread safety [1][2]. This patch adds an explanation.

Following are the trivial problems:
- chardev.c
  - Move the "msg_ptr" pointer into the read function to remove unnecessary usage.
  - List the clear states of "already_open" by using mnemonic enumeration.

- chardev2.c
  - The "buffer" in the write function is user space data. It cannot use in the kernel space.
  - Reduce the redundant type transformation.
  - List the states of "already_open". Same as chardev.c.

[1] https://lore.kernel.org/lkml/20140303210359.26624.qmail@science.horizon.com/T/#u
[2] torvalds/linux@9c225f2

- sysprog21/lkmpg: https://github.com/sysprog21/lkmpg/issues/93