### PR TITLE
Keep workflow running even if no release tag found

### DIFF
--- a/.github/workflows/generate_doc.yaml
+++ b/.github/workflows/generate_doc.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           token: ${{ github.token }}
           fail-if-no-assets: false
+          fail-if-no-release: false
           tag: latest
           assets: |
             lkmpg.pdf


### PR DESCRIPTION
The action we used to delete the old release somehow cannot find the
release tag in forked repo and cause the workflow failed.
To solve this issue, simply setting `fail-if-no-release` option to false
will do the trick.

The example of failed workflow:
https://github.com/FennecJ-Test/lkmpg/runs/3696212913?check_suite_focus=true

After setting `fail-if-no-release` option to false, it can work well:
https://github.com/FennecJ-Test/lkmpg/runs/3696371773?check_suite_focus=true

By the way, I noticed that `set -x` in `.ci/check-format.sh` caused the output of the workflow log to be a little complicated.
Was the option set on purpose?