### PR TITLE
Correct English gramma

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -563,7 +563,7 @@ $ make
   HOSTLD  scripts/kconfig/conf
 \end{verbatim}
 
-If you do not desire to actually compile the kernel, you can interrupt the build process (CTRL-C) just after the SPLIT line, because at that time, the files you need will be are ready.
+If you do not desire to actually compile the kernel, you can interrupt the build process (CTRL-C) just after the SPLIT line, because at that time, the files you need are ready.
 Now you can turn back to the directory of your module and compile it: It will be built exactly according to your current kernel settings, and it will load into it without any errors.
 
 \section{Preliminaries}


### PR DESCRIPTION
Correct English gramma

Original text : within "because at that time, the files you need will be are ready.",  "will be" is redundant.
Corrected text : "because at that time, the files you need are ready."