### PR TITLE
Generate contributor list as a modular inclusion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+JianXing Wu <fdgkhdkgh@gmail.com> 吳建興 <fdgkhdkgh@gmail.com>
+fennecJ     <hwahwa649@gmail.com> fennecJ   <58484289+fennecJ@users.noreply.github.com>
+fennecJ     <hwahwa649@gmail.com> fennecj   <hwahwa649@gmail.com>
+Jim Huang   <jserv.tw@gmail.com> Jim Huang  <jserv@ccns.ncku.edu.tw>
+Jim Huang   <jserv.tw@gmail.com> Jim Huang  <jserv@biilabs.io>
+linD026     <shiyn.lin@gmail.com> linD026   <66012716+linD026@users.noreply.github.com>
+linD026     <shiyn.lin@gmail.com> linD026   <0086d026@email.ntou.edu.tw>
+linD026     <shiyn.lin@gmail.com> linzhien  <0086d026@email.ntou.edu.tw>

--- a/contrib.tex
+++ b/contrib.tex
@@ -1,0 +1,33 @@
+2011eric,                      % <20110901eric@outlook.com>
+25077667,                      % <zxc25077667@gmail.com>
+Arush Sharma,                  % <46960231+arushsharma24@users.noreply.github.com>
+asas1asas200,                  % <asas1asas200@gmail.com>
+Benno Bielmeier,               % <32938211+bbenno@users.noreply.github.com>
+Brad Baker,                    % <brad@brdbkr.com>
+ccs100203,                     % <ccs100203@gmail.com>
+Chih-Yu Chen,                  % <34228283+chihyu1206@users.noreply.github.com>
+ChinYikMing,                   % <yikming2222@gmail.com>
+Cyril Brulebois,               % <cyril@debamax.com>
+Daniele Paolo Scarpazza,       % <>
+David Porter,                  % <>
+demonsome,                     % <horseradish1208@gmail.com>
+Dimo Velev,                    % <>
+Ekang Monyet,                  % <ekangmonyet@posteo.net>
+fennecJ,                       % <hwahwa649@gmail.com>
+Francois Audeon,               % <>
+gagachang,                     % <vivahavey@gmail.com>
+Gilad Reti,                    % <gilad.reti@gmail.com>
+Horst Schirmeier,              % <>
+Hsin-Hsiang Peng,              % <hsinspeng@gmail.com>
+Ignacio Martin,                % <>
+JianXing Wu,                   % <fdgkhdkgh@gmail.com>
+linD026,                       % <shiyn.lin@gmail.com>
+Marconi Jiang,                 % <marconi1964@yahoo.com>
+RinHizakura,                   % <s921975628@gmail.com>
+Roman Lakeev,                  % <>
+Stacy Prowell,                 % <sprowell@gmail.com>
+Tucker Polomik,                % <tucker.polomik@inficon.com>
+VxTeemo,                       % <tcccvvv123@gmail.com>
+Wei-Lun Tsai,                  % <alan23273850@gmail.com>
+xatier,                        % <xatierlike@gmail.com>
+Ylowy.                         % <69316865+YLowy@users.noreply.github.com>

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -82,7 +82,11 @@ Jim Huang upgraded to recent kernel versions (v5.x) and revised the \LaTeX\ docu
 \subsection{Acknowledgements}
 \label{sec:acknowledgements}
 
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, and Roman Lakeev.
+The following people have contributed corrections or good suggestions: 
+
+\begin{flushleft}
+\input{contrib}
+\end{flushleft}
 
 \subsection{What Is A Kernel Module?}
 \label{sec:kernelmod}

--- a/scripts/Contributors
+++ b/scripts/Contributors
@@ -1,0 +1,33 @@
+2011eric,<20110901eric@outlook.com>
+25077667,<zxc25077667@gmail.com>
+Arush Sharma,<46960231+arushsharma24@users.noreply.github.com>
+asas1asas200,<asas1asas200@gmail.com>
+Benno Bielmeier,<32938211+bbenno@users.noreply.github.com>
+Brad Baker,<brad@brdbkr.com>
+ccs100203,<ccs100203@gmail.com>
+Chih-Yu Chen,<34228283+chihyu1206@users.noreply.github.com>
+ChinYikMing,<yikming2222@gmail.com>
+Cyril Brulebois,<cyril@debamax.com>
+Daniele Paolo Scarpazza,<>
+David Porter,<>
+demonsome,<horseradish1208@gmail.com>
+Dimo Velev,<>
+Ekang Monyet,<ekangmonyet@posteo.net>
+fennecJ,<hwahwa649@gmail.com>,<58484289+fennecJ@users.noreply.github.com>
+Francois Audeon,<>
+gagachang,<vivahavey@gmail.com>
+Gilad Reti,<gilad.reti@gmail.com>
+Horst Schirmeier,<>
+Hsin-Hsiang Peng,<hsinspeng@gmail.com>
+Ignacio Martin,<>
+JianXing Wu,<fdgkhdkgh@gmail.com>
+linD026,<shiyn.lin@gmail.com>,<0086d026@email.ntou.edu.tw>,<66012716+linD026@users.noreply.github.com>
+Marconi Jiang,<marconi1964@yahoo.com>
+RinHizakura,<s921975628@gmail.com>
+Roman Lakeev,<>
+Stacy Prowell,<sprowell@gmail.com>
+Tucker Polomik,<tucker.polomik@inficon.com>
+VxTeemo,<tcccvvv123@gmail.com>
+Wei-Lun Tsai,<alan23273850@gmail.com>
+xatier,<xatierlike@gmail.com>
+Ylowy,<69316865+YLowy@users.noreply.github.com>

--- a/scripts/Exclude
+++ b/scripts/Exclude
@@ -1,0 +1,1 @@
+Jim Huang,              One of main author

--- a/scripts/Include
+++ b/scripts/Include
@@ -1,0 +1,7 @@
+Daniele Paolo Scarpazza,<>
+David Porter,<>
+Dimo Velev,<>
+Francois Audeon,<>
+Horst Schirmeier,<>
+Ignacio Martin,<>
+Roman Lakeev,<>

--- a/scripts/list-contributors.sh
+++ b/scripts/list-contributors.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+FORMAT="%aN,<%aE>"                   #Set git output format in "Name,<Email>" //Capital in aN and aE means replace str based on .mailmap
+TARGET=(examples lkmpg.tex)          #Target files we want to trace
+DIR=`git rev-parse --show-toplevel`  #Get root dir of the repo
+TARGET=("${TARGET[@]/#/$DIR/}")      #Concat $DIR BEFORE ALL elements in array TARGET
+
+#The str in each line should be Username,<useremail>
+function gen-raw-list()
+{
+    git log --pretty="$FORMAT" ${TARGET[@]} | sort -u
+}
+
+function parse-list()
+{
+    > Contributors  # Clear contributors' list (Overwrite with null)
+    while read -r line; do
+        User=`echo "$line" | awk -F "," '{print $1}'`   
+        if [[ `grep -w "$User" Exclude` ]]; then
+            echo "[skip] $User"
+            continue;
+        fi
+        echo "[Add] $User"
+        MainMail=`echo "$line" | awk -F "[<*>]" '{print $2}'`
+        Emails=(`cat $DIR/.mailmap | grep -w "$User" | awk -F "[<*>]" '{print $4}' | sort -u`)
+        for Email in ${Emails[@]}; do
+            if [[ "$Email" != "$MainMail" ]]; then
+                line="$line,<$Email>";
+            fi
+        done
+        echo "$line" >> Contributors
+    done <<< $(gen-raw-list)
+    cat Include >> Contributors
+}
+
+function sort-list()
+{
+    if [[ `git diff Contributors` ]]; then
+        sort -f -o Contributors{,}
+        git add $DIR/scripts/Contributors
+    fi
+}
+
+#For all lines before endline, print "name, % <email>"
+#For endline print "name. % <email>"
+function gen-tex-file()
+{
+    cat Contributors | awk -F "," \
+    '   BEGIN{k=0}{name[k]=$1;email[k++]=$2}
+        END{
+           for(i=0;i<k;i++){
+               name[i]=(i<k-1)?name[i]",":name[i]".";
+               printf("%-30s %% %s\n",name[i],email[i]);
+               }
+           }
+    '
+}
+
+parse-list
+sort-list
+gen-tex-file > $DIR/contrib.tex


### PR DESCRIPTION
This script do mainly 2 things:
1.
Generate file `Contributors` with git log in following format:
Contributor's name,<1-st e-mail>[,<2nd e-mail>][,<3rd e-mail>]...
The 2-nd email and so on are based on file `.mailmap` in the root
directory of the repo.
Note that it will also append contributors in File `Include`; and
will NOT append contributors in File `Exclude`.
If there are new contributors, script will sort `Contributor` after
append new contributors into each file; Otherwise it do nothing.

2.
Generate contrib.tex based on `Contributors` into lib/contrib.tex in
following format:
[name], (reasonable width) % [1-st e-mail]
Which is inspired by The Not So Short Introduction to Latex 2e[1]

We need to maintain `.mailmap`, `Exclude` and `Include` manually.
All Chinese name should be converted into English/Pinyin in `.mailmap`,
otherwise we may need extra pkg for latex to parse Chinese characters.

[1] - https://tobi.oetiker.ch/lshort/lshort.pdf

Close sysprog21#68