### PR TITLE
7.4: adjust the position of Figure 1.

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1061,7 +1061,7 @@ That means that at the end of function \cpp|stop()|, the function \cpp|start()| 
 This loop finishes when the function \cpp|start()| returns \cpp|NULL|.
 You can see a scheme of this in the Figure~\ref{img:seqfile}.
 
-\begin{figure}
+\begin{figure}[h]
   \center
   \begin{tikzpicture}[node distance=2cm, thick]
     \node (start) [startstop] {start() treatment};


### PR DESCRIPTION
The Figure 1. was located in procfs4.c sample code.
Which make the sample code be fragmented, and hard to read.

Puting the Figure 1. at the same place it occurs in source text.