### PR TITLE
Update `$(PWD) -> $(shell pwd)` in Makefile in Section 4

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -220,10 +220,10 @@ Now you will need a \verb|Makefile|. If you copy and paste this, change the inde
 obj-m += hello-1.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
 \end{code}
 
 And finally just:
@@ -328,10 +328,10 @@ obj-m += hello-1.o
 obj-m += hello-2.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
 \end{code}
 
 Now have a look at \src{drivers/char/Makefile} for a real world example.
@@ -469,10 +469,10 @@ obj-m += startstop.o
 startstop-objs := start.o stop.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
 \end{code}
 
 This is the complete makefile for all the examples we have seen so far.


### PR DESCRIPTION
Hello, everyone

I Update `$(PWD)` to `$(shell pwd)` at Makefile in Section 4. There are 6 changes in total. (Section 4.1, 4.2, 4.6).

My Laptop has installed openSUSE Tumbleweed distro, when I try hello-1 example, it will fail during the make progross. Here are error info:

```shell
╭─mengxinayan@Tumbleweed ~/code/lkmpg
╰─$ sudo make              
make: PWD: No such file or directory
make -C /lib/modules/5.14.14-1-default/build M= modules 
make[1]: Entering directory '/usr/src/linux-5.14.14-1-obj/x86_64/default'
  GEN     Makefile
make[3]: *** No rule to make target 'arch/x86/entry/syscalls/syscall_32.tbl', needed by 'arch/x86/include/generated/uapi/asm/unistd_32.h'.  Stop.
make[2]: *** [/usr/src/linux-5.14.14-1/arch/x86/Makefile:231: archheaders] Error 2
make[1]: *** [/usr/src/linux-5.14.14-1/Makefile:220: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-5.14.14-1-obj/x86_64/default'
make: *** [Makefile:4: all] Error 2
```

It will report [ERROR] because `make: PWD: No such file or directory`.  So I replaced `$(PWD)` with `$(shell pwd)` in Makefile on my laptop, it will work well.

```bash
╭─mengxinayan@Tumbleweed ~/code/lkmpg
╰─$ sudo make 
make -C /lib/modules/5.14.14-1-default/build M=/home/mengxinayan/code/lkmpg modules 
make[1]: Entering directory '/usr/src/linux-5.14.14-1-obj/x86_64/default'
  CC [M]  /home/mengxinayan/code/lkmpg/hello-1.o
  MODPOST /home/mengxinayan/code/lkmpg/Module.symvers
  CC [M]  /home/mengxinayan/code/lkmpg/hello-1.mod.o
  LD [M]  /home/mengxinayan/code/lkmpg/hello-1.ko
  BTF [M] /home/mengxinayan/code/lkmpg/hello-1.ko
Skipping BTF generation for /home/mengxinayan/code/lkmpg/hello-1.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-5.14.14-1-obj/x86_64/default'
```

So I changed all `$(PWD)` to `$(shell pwd)` in Makefile.

Thanks.