### PR TITLE
Fix a logic error in examples/ioctl.c

### DIFF
--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -149,8 +149,8 @@ static struct file_operations fops = {
 static int ioctl_init(void)
 {
     dev_t dev;
-    int alloc_ret = 0;
-    int cdev_ret = 0;
+    int alloc_ret = -1;
+    int cdev_ret = -1;
     alloc_ret = alloc_chrdev_region(&dev, 0, num_of_dev, DRIVER_NAME);
 
     if (alloc_ret)


### PR DESCRIPTION
Change the `alloc_ret` and `cdev_ret` initial values to non-zero, or it
will `cdev_del()` uninitialized and not-yet-added `test_ioctl_cdev` after
`alloc_chrdev_region()` failed.