### PR TITLE
Fix typo, grammar and remove duplicated words

### DIFF
--- a/examples/bottomhalf.c
+++ b/examples/bottomhalf.c
@@ -5,7 +5,7 @@
  * from:
  *    https://github.com/wendlers/rpi-kmod-samples
  *
- * Press one button to turn on a LED and another to turn it off
+ * Press one button to turn on an LED and another to turn it off
  */
 
 #include <linux/delay.h>

--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -100,7 +100,7 @@ static int device_release(struct inode *inode, struct file *file)
     atomic_set(&already_open, CDEV_NOT_USED);
 
     /* Decrement the usage count, or else once you opened the file, you will
-     * never get get rid of the module.
+     * never get rid of the module.
      */
     module_put(THIS_MODULE);
 

--- a/examples/example_tasklet.c
+++ b/examples/example_tasklet.c
@@ -6,7 +6,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 
-/* Macro DECLARE_TASKLET_OLD exists for compatibiity.
+/* Macro DECLARE_TASKLET_OLD exists for compatibility.
  * See https://lwn.net/Articles/830964/
  */
 #ifndef DECLARE_TASKLET_OLD

--- a/examples/print_string.c
+++ b/examples/print_string.c
@@ -50,7 +50,7 @@ static void print_string(char *str)
          *
          * This is why text files are different between Unix and MS Windows.
          * In CP/M and derivatives, like MS-DOS and MS Windows, the ASCII
-         * standard was strictly adhered to, and therefore a newline requirs
+         * standard was strictly adhered to, and therefore a newline requires
          * both a LF and a CR.
          */
         (ttyops->write)(my_tty, "\015\012", 2);


### PR DESCRIPTION
Replaced 'a' with 'an' since a vowel sound is after.