### PR TITLE
Use latexmk instead of pdflatex for PDF generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ lkmpg.pdf
 *.toc
 *.bbl
 *.blg
+*.fdb_latexmk 
+*.fls
 
 # make4ht
 *.html

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@ PROJ = lkmpg
 all: $(PROJ).pdf
 
 $(PROJ).pdf: lkmpg.tex
-	pdflatex -shell-escap $<
-	bibtex $(PROJ) >/dev/null || echo
-	pdflatex -shell-escape $< 2>/dev/null >/dev/null
 	rm -rf _minted-$(PROJ)
+	latexmk -shell-escape lkmpg.tex -pdf
 
 html: lkmpg.tex html.cfg assets/Manrope_variable.ttf
 	sed $ 's/\t/    /g' lkmpg.tex > lkmpg-for-ht.tex
@@ -19,7 +17,7 @@ indent:
 	(cd examples; find . -name '*.[ch]' | xargs clang-format -i)
 
 clean:
-	rm -f *.dvi *.aux *.log *.ps *.pdf *.out lkmpg.bbl lkmpg.blg lkmpg.lof lkmpg.toc
+	rm -f *.dvi *.aux *.log *.ps *.pdf *.out lkmpg.bbl lkmpg.blg lkmpg.lof lkmpg.toc lkmpg.fdb_latexmk lkmpg.fls
 	rm -rf html
 
 .PHONY: html

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROJ = lkmpg
 all: $(PROJ).pdf
 
 $(PROJ).pdf: lkmpg.tex
+	@if ! hash latexmk; then echo "No Latexmk found. See https://mg.readthedocs.io/latexmk.html for installation."; exit 1; fi
 	rm -rf _minted-$(PROJ)
 	latexmk -shell-escape lkmpg.tex -pdf
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ $ brew install --cask mactex
 $ sudo tlmgr update --self
 ```
 
+Note that `latexmk` is required to generated PDF, and it probably has been installed on your OS already. If not, please follow the [installation guide](https://mg.readthedocs.io/latexmk.html#installation).
+
 Alternatively, using [Docker](https://docs.docker.com/) is recommended, as it guarantees the same dependencies with our GitHub Actions workflow.
 After install [docker engine](https://docs.docker.com/engine/install/) on your machine, pull the docker image [twtug/lkmpg](https://hub.docker.com/r/twtug/lkmpg) and run in isolated containers.
 


### PR DESCRIPTION
The current Makefile is missing one more `pdflatex` pass.
    
The correct steps are : `pdflatex -> bibtex -> pdflatex -> pdflatex` as shown in the reference [here](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile#latex-recipes). 

Otherwise, bib items will not be showing properly.

`.gitignore` has been updated accordingly.