### PR TITLE
Fix the buffer length may cause a read error

### DIFF
--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -36,7 +36,7 @@ enum {
 /* Is device open? Used to prevent multiple access to device */
 static atomic_t already_open = ATOMIC_INIT(CDEV_NOT_USED);
 
-static char msg[BUF_LEN]; /* The msg the device will give when asked */
+static char msg[BUF_LEN + 1]; /* The msg the device will give when asked */
 
 static struct class *cls;
 

--- a/examples/chardev2.c
+++ b/examples/chardev2.c
@@ -28,7 +28,7 @@ enum {
 static atomic_t already_open = ATOMIC_INIT(CDEV_NOT_USED);
 
 /* The message the device will give when asked */
-static char message[BUF_LEN];
+static char message[BUF_LEN + 1];
 
 static struct class *cls;
 


### PR DESCRIPTION
Since The length of the message buffer is BUF_LEN. When writing the BUF_LEN length of the string it will overwrite the last character (usually it is '\0' from the initialization). And, because the read operation uses the character in the message buffer ('\0') to stop the read loop. It will cause the read operation will read out of the message buffer when the length parameter of read() is not lower than or equal to BUF_LEN.

---

Related discussion:
* https://github.com/sysprog21/lkmpg/issues/158