### PR TITLE
procfs{2, 3}: Change to use offset parameter

### DIFF
--- a/examples/procfs2.c
+++ b/examples/procfs2.c
@@ -55,6 +55,7 @@ static ssize_t procfile_write(struct file *file, const char __user *buff,
         return -EFAULT;
 
     procfs_buffer[procfs_buffer_size & (PROCFS_MAX_SIZE - 1)] = '\0';
+    *off += procfs_buffer_size;
     pr_info("procfile write %s\n", procfs_buffer);
 
     return procfs_buffer_size;


### PR DESCRIPTION
To make sure the behavior of the read and write operations are correct with offset, update it each time. Also, since it is using the offset, modify the part of read for removing unnecessary variable.

---
Related discussion:
* https://github.com/sysprog21/lkmpg/issues/158