### PR TITLE
Improve the compatibility with kernel < v5.10

### DIFF
--- a/examples/procfs3.c
+++ b/examples/procfs3.c
@@ -8,7 +8,9 @@
 #include <linux/sched.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
 #include <linux/minmax.h>
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
 #define HAVE_PROC_OPS


### PR DESCRIPTION
min()/max() splited from kernel.h to minmax.h since v5.10-rc1. Before v5.10, minmax.h doesn't exist [1].

[1] https://github.com/torvalds/linux/commit/b296a6d53339a79082c1d2c1761e948e8b3def69