### PR TITLE
vinput: Fix missing error code

### DIFF
--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -369,6 +369,7 @@ static int __init vinput_init(void)
     vinput_dev = register_chrdev(0, DRIVER_NAME, &vinput_fops);
     if (vinput_dev < 0) {
         pr_err("vinput: Unable to allocate char dev region\n");
+        err = vinput_dev;
         goto failed_alloc;
     }
 


### PR DESCRIPTION
Fix the missing error code when register_chrdev() failed. The report is from Smatch:

```
Smatch failed: 1 warning(s), 0 error(s)
/home/runner/work/lkmpg/lkmpg/examples/vinput.c:372 vinput_init() warn: missing error code 'err'
```