### PR TITLE
Discourage kernel.h usage and other header cleanups

### DIFF
--- a/examples/bottomhalf.c
+++ b/examples/bottomhalf.c
@@ -11,8 +11,8 @@
 #include <linux/delay.h>
 #include <linux/gpio.h>
 #include <linux/interrupt.h>
-#include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/printk.h>
 
 /* Macro DECLARE_TASKLET_OLD exists for compatibiity.
  * See https://lwn.net/Articles/830964/

--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -3,15 +3,19 @@
  * you have read from the dev file
  */
 
+#include <linux/atomic.h>
 #include <linux/cdev.h>
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/fs.h>
 #include <linux/init.h>
-#include <linux/irq.h>
-#include <linux/kernel.h>
+#include <linux/kernel.h> /* for sprintf() */
 #include <linux/module.h>
-#include <linux/poll.h>
+#include <linux/printk.h>
+#include <linux/types.h>
+#include <linux/uaccess.h> /* for get_user and put_user */
+
+#include <asm/errno.h>
 
 /*  Prototypes - this would normally go in a .h file */
 static int device_open(struct inode *, struct file *);

--- a/examples/chardev2.c
+++ b/examples/chardev2.c
@@ -2,15 +2,17 @@
  * chardev2.c - Create an input/output character device
  */
 
+#include <linux/atomic.h>
 #include <linux/cdev.h>
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/fs.h>
 #include <linux/init.h>
-#include <linux/irq.h>
-#include <linux/kernel.h> /* We are doing kernel work */
 #include <linux/module.h> /* Specifically, a module */
-#include <linux/poll.h>
+#include <linux/printk.h>
+#include <linux/types.h>
+
+#include <asm/errno.h>
 
 #include "chardev.h"
 #define SUCCESS 0

--- a/examples/completions.c
+++ b/examples/completions.c
@@ -4,9 +4,9 @@
 #include <linux/completion.h>
 #include <linux/err.h> /* for IS_ERR() */
 #include <linux/init.h>
-#include <linux/kernel.h>
 #include <linux/kthread.h>
 #include <linux/module.h>
+#include <linux/printk.h>
 
 static struct {
     struct completion crank_comp;

--- a/examples/completions.c
+++ b/examples/completions.c
@@ -2,6 +2,7 @@
  * completions.c
  */
 #include <linux/completion.h>
+#include <linux/err.h> /* for IS_ERR() */
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/kthread.h>

--- a/examples/devicemodel.c
+++ b/examples/devicemodel.c
@@ -63,7 +63,6 @@ static struct platform_driver devicemodel_driver = {
     .driver =
         {
             .name = "devicemodel_example",
-            .owner = THIS_MODULE,
             .pm = &devicemodel_pm_ops,
         },
     .probe = devicemodel_probe,

--- a/examples/example_atomic.c
+++ b/examples/example_atomic.c
@@ -3,8 +3,8 @@
  */
 #include <linux/atomic.h>
 #include <linux/bitops.h>
-#include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/printk.h>
 
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
 #define BYTE_TO_BINARY(byte)                                                   \

--- a/examples/example_atomic.c
+++ b/examples/example_atomic.c
@@ -1,7 +1,8 @@
 /*
  * example_atomic.c
  */
-#include <linux/interrupt.h>
+#include <linux/atomic.h>
+#include <linux/bitops.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 

--- a/examples/example_mutex.c
+++ b/examples/example_mutex.c
@@ -1,7 +1,6 @@
 /*
  * example_mutex.c
  */
-#include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/mutex.h>

--- a/examples/example_mutex.c
+++ b/examples/example_mutex.c
@@ -1,9 +1,9 @@
 /*
  * example_mutex.c
  */
-#include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
+#include <linux/printk.h>
 
 static DEFINE_MUTEX(mymutex);
 

--- a/examples/example_rwlock.c
+++ b/examples/example_rwlock.c
@@ -1,9 +1,9 @@
 /*
  * example_rwlock.c
  */
-#include <linux/interrupt.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/rwlock.h>
 
 static DEFINE_RWLOCK(myrwlock);
 

--- a/examples/example_rwlock.c
+++ b/examples/example_rwlock.c
@@ -1,8 +1,8 @@
 /*
  * example_rwlock.c
  */
-#include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/printk.h>
 #include <linux/rwlock.h>
 
 static DEFINE_RWLOCK(myrwlock);

--- a/examples/example_spinlock.c
+++ b/examples/example_spinlock.c
@@ -2,8 +2,8 @@
  * example_spinlock.c
  */
 #include <linux/init.h>
-#include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/printk.h>
 #include <linux/spinlock.h>
 
 static DEFINE_SPINLOCK(sl_static);

--- a/examples/example_spinlock.c
+++ b/examples/example_spinlock.c
@@ -2,7 +2,6 @@
  * example_spinlock.c
  */
 #include <linux/init.h>
-#include <linux/interrupt.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/spinlock.h>

--- a/examples/example_tasklet.c
+++ b/examples/example_tasklet.c
@@ -3,8 +3,8 @@
  */
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/printk.h>
 
 /* Macro DECLARE_TASKLET_OLD exists for compatibility.
  * See https://lwn.net/Articles/830964/

--- a/examples/hello-1.c
+++ b/examples/hello-1.c
@@ -1,8 +1,8 @@
 /*
  * hello-1.c - The simplest kernel module.
  */
-#include <linux/kernel.h> /* Needed for pr_info() */
 #include <linux/module.h> /* Needed by all modules */
+#include <linux/printk.h> /* Needed for pr_info() */
 
 int init_module(void)
 {

--- a/examples/hello-2.c
+++ b/examples/hello-2.c
@@ -3,8 +3,8 @@
  * This is preferred over using init_module() and cleanup_module().
  */
 #include <linux/init.h> /* Needed for the macros */
-#include <linux/kernel.h> /* Needed for pr_info() */
 #include <linux/module.h> /* Needed by all modules */
+#include <linux/printk.h> /* Needed for pr_info() */
 
 static int __init hello_2_init(void)
 {

--- a/examples/hello-3.c
+++ b/examples/hello-3.c
@@ -2,8 +2,8 @@
  * hello-3.c - Illustrating the __init, __initdata and __exit macros.
  */
 #include <linux/init.h> /* Needed for the macros */
-#include <linux/kernel.h> /* Needed for pr_info() */
 #include <linux/module.h> /* Needed by all modules */
+#include <linux/printk.h> /* Needed for pr_info() */
 
 static int hello3_data __initdata = 3;
 

--- a/examples/hello-4.c
+++ b/examples/hello-4.c
@@ -2,8 +2,8 @@
  * hello-4.c - Demonstrates module documentation.
  */
 #include <linux/init.h> /* Needed for the macros */
-#include <linux/kernel.h> /* Needed for pr_info() */
 #include <linux/module.h> /* Needed by all modules */
+#include <linux/printk.h> /* Needed for pr_info() */
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("LKMPG");

--- a/examples/hello-5.c
+++ b/examples/hello-5.c
@@ -2,9 +2,10 @@
  * hello-5.c - Demonstrates command line argument passing to a module.
  */
 #include <linux/init.h>
-#include <linux/kernel.h>
+#include <linux/kernel.h> /* for ARRAY_SIZE() */
 #include <linux/module.h>
 #include <linux/moduleparam.h>
+#include <linux/printk.h>
 #include <linux/stat.h>
 
 MODULE_LICENSE("GPL");

--- a/examples/intrpt.c
+++ b/examples/intrpt.c
@@ -10,8 +10,9 @@
 
 #include <linux/gpio.h>
 #include <linux/interrupt.h>
-#include <linux/kernel.h>
+#include <linux/kernel.h> /* for ARRAY_SIZE() */
 #include <linux/module.h>
+#include <linux/printk.h>
 
 static int button_irqs[] = { -1, -1 };
 

--- a/examples/sleep.c
+++ b/examples/sleep.c
@@ -5,8 +5,9 @@
 
 #include <linux/atomic.h>
 #include <linux/fs.h>
-#include <linux/kernel.h> /* We're doing kernel work */
+#include <linux/kernel.h> /* for sprintf() */
 #include <linux/module.h> /* Specifically, a module */
+#include <linux/printk.h>
 #include <linux/proc_fs.h> /* Necessary because we use proc fs */
 #include <linux/types.h>
 #include <linux/uaccess.h> /* for get_user and put_user */

--- a/examples/sleep.c
+++ b/examples/sleep.c
@@ -3,13 +3,19 @@
  * at the same time, put all but one to sleep.
  */
 
+#include <linux/atomic.h>
+#include <linux/fs.h>
 #include <linux/kernel.h> /* We're doing kernel work */
 #include <linux/module.h> /* Specifically, a module */
 #include <linux/proc_fs.h> /* Necessary because we use proc fs */
-#include <linux/sched.h> /* For putting processes to sleep and
-                                   waking them up */
+#include <linux/types.h>
 #include <linux/uaccess.h> /* for get_user and put_user */
 #include <linux/version.h>
+#include <linux/wait.h> /* For putting processes to sleep and
+                                   waking them up */
+
+#include <asm/current.h>
+#include <asm/errno.h>
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
 #define HAVE_PROC_OPS

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -401,7 +401,7 @@ The \cpp|cleanup_module()| function is supposed to undo whatever \cpp|init_modul
 
 Lastly, every kernel module needs to include \verb|<linux/module.h>|.
 % TODO: adjust the section anchor
-We needed to include \verb|<linux/kernel.h>| only for the macro expansion for the \cpp|pr_alert()| log level, which you'll learn about in Section \ref{sec:printk}.
+We needed to include \verb|<linux/printk.h>| only for the macro expansion for the \cpp|pr_alert()| log level, which you'll learn about in Section \ref{sec:printk}.
 
 \begin{enumerate}
   \item A point about coding style.


### PR DESCRIPTION
We do not want to encourage people to use garbage which is kernel.h. The rule of thumb is to include the headers we are the direct users of. Clean up a bit the examples and text  of the book.

**UPDATE**
Besides that the examples have rather random headers. This has to be revisited and updated. In this PR it's a subset of the fixes of the mess.
