### PR TITLE
CI: Switch Smatch source code to GitHub mirror

### DIFF
--- a/.ci/static-analysis.sh
+++ b/.ci/static-analysis.sh
@@ -84,13 +84,12 @@ function do_gcc()
 
 function do_smatch()
 {
-    wget -q https://repo.or.cz/smatch.git/snapshot/refs/heads/master.tar.gz
+    git clone https://github.com/error27/smatch.git --depth=1
     if [ $? -ne 0 ]; then
         echo "Failed to download smatch."
         exit 1
     fi
-    tar -xzf master.tar.gz
-    pushd smatch-master-*
+    pushd smatch
     make smatch || exit 1
     local SMATCH=$(pwd)/smatch
     popd


### PR DESCRIPTION
Since the Smatch repository is unavailable recently [1], let's switch to GitHub mirror, https://github.com/error27/smatch.git [2], instead of using https://repo.or.cz/smatch.git.

[1] https://lore.kernel.org/all/Y1qf7w%2Fjo8FH5I8G@kadam/
[2] https://lore.kernel.org/all/20220810105926.GS3460@kadam/

Close #201