### PR TITLE
Cleanup redundant workflow step, fix release body and timestamp

### DIFF
--- a/.github/workflows/build-deploy-assets.yaml
+++ b/.github/workflows/build-deploy-assets.yaml
@@ -18,16 +18,6 @@ jobs:
           make all
           make html
           tar zcvf lkmpg-html.tar.gz ./html
-      - name: Delete old release asset
-        uses: mknejp/delete-release-assets@v1
-        with:
-          token: ${{ github.token }}
-          fail-if-no-assets: false
-          fail-if-no-release: false
-          tag: latest
-          assets: |
-            lkmpg.pdf
-            lkmpg-html.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v0.1.15
         with:

--- a/.github/workflows/build-deploy-assets.yaml
+++ b/.github/workflows/build-deploy-assets.yaml
@@ -18,6 +18,14 @@ jobs:
           make all
           make html
           tar zcvf lkmpg-html.tar.gz ./html
+      - name: Delete old release
+        uses: cb80/delrel@latest
+        with:
+          tag: latest
+      - name: Tag
+        run: |
+          git tag latest
+          git push -f --tags
       - name: Release
         uses: softprops/action-gh-release@v0.1.15
         with:


### PR DESCRIPTION
This PR removes a redundant step from existing workflow and addresses a minor issue when publishing a "nightly" release using the current workflow.

Since softprops/action-gh-release#134 is upstreamed, #29 is no longer needed and is reverted as the assets file can be replaced correctly.  Note that the current behavior of the action will remove all existing assets and replace it with **only** the files listed.

Currently, the release body and timestamp is not updated due to the *update-or-create* logic, and it is not possible to update the timestamp of a release using any existing Github API without recreating the release (related issue: softprops/action-gh-release#171).  The release body is not updated as the tag already exists thus the current commit will not be re-tagged.  Removing both the existing release and tag triggers the creation path which update the body, timestamp and also re-point `latest` tag to the current commit.

The `Delete old release` step may be removed if softprops/action-gh-release#181 is merged in the future.