### PR TITLE
Add `#include<linux/jump_label.h>` to static_key.c

### DIFF
--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -10,6 +10,7 @@
 #include <linux/printk.h>
 #include <linux/types.h>
 #include <linux/uaccess.h> /* for get_user and put_user */
+#include <linux/jump_label.h> /* for static key macros */
 
 #include <asm/errno.h>
 

--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -136,7 +136,7 @@ static ssize_t device_read(struct file *filp, /* see include/linux/fs.h */
 
     msg_ptr += *offset;
 
-    /* Actually put the date into the buffer */
+    /* Actually put the data into the buffer */
     while (length && *msg_ptr) {
         /**
          * The buffer is in the user data segment, not the kernel


### PR DESCRIPTION
Add this include for the static key macros.