### PR TITLE
procfs: Remove unnecessary cleanup on proc_create failure

### DIFF
--- a/examples/procfs2.c
+++ b/examples/procfs2.c
@@ -77,7 +77,6 @@ static int __init procfs2_init(void)
 {
     our_proc_file = proc_create(PROCFS_NAME, 0644, NULL, &proc_file_fops);
     if (NULL == our_proc_file) {
-        proc_remove(our_proc_file);
         pr_alert("Error:Could not initialize /proc/%s\n", PROCFS_NAME);
         return -ENOMEM;
     }

--- a/examples/procfs3.c
+++ b/examples/procfs3.c
@@ -82,7 +82,6 @@ static int __init procfs3_init(void)
     our_proc_file = proc_create(PROCFS_ENTRY_FILENAME, 0644, NULL,
                                 &file_ops_4_our_proc_file);
     if (our_proc_file == NULL) {
-        remove_proc_entry(PROCFS_ENTRY_FILENAME, NULL);
         pr_debug("Error: Could not initialize /proc/%s\n",
                  PROCFS_ENTRY_FILENAME);
         return -ENOMEM;

--- a/examples/procfs4.c
+++ b/examples/procfs4.c
@@ -98,7 +98,6 @@ static int __init procfs4_init(void)
 
     entry = proc_create(PROC_NAME, 0, NULL, &my_file_ops);
     if (entry == NULL) {
-        remove_proc_entry(PROC_NAME, NULL);
         pr_debug("Error: Could not initialize /proc/%s\n", PROC_NAME);
         return -ENOMEM;
     }

--- a/examples/sleep.c
+++ b/examples/sleep.c
@@ -194,7 +194,6 @@ static int __init sleep_init(void)
     our_proc_file =
         proc_create(PROC_ENTRY_FILENAME, 0644, NULL, &file_ops_4_our_proc_file);
     if (our_proc_file == NULL) {
-        remove_proc_entry(PROC_ENTRY_FILENAME, NULL);
         pr_debug("Error: Could not initialize /proc/%s\n", PROC_ENTRY_FILENAME);
         return -ENOMEM;
     }


### PR DESCRIPTION
I found it unneccesary to call `proc_remove` or `remove_proc_entry` when `proc_create` returns NULL.
I searched through kernel and found existing code never call remove on failed creates.
I read the kernel source of drivers/input/input.c