### PR TITLE
Refine LaTeX package prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For Ubuntu Linux, macOS, and other Unix-like systems, run the following command(
 
 ```bash
 # Debian / Ubuntu
-$ sudo apt install make texlive-full
+$ sudo apt install make texlive-xetex
 
 # Arch / Manjaro
 $ sudo pacman -S make texlive-most texlive-bin


### PR DESCRIPTION
In line 30, it is sufficient to install xetex in order to save time, and to avoid compiling errors due to multi-version tex installation.

texlive-full includes all kinds of tex, saying luatex, xetex, pdflatex, and the installation takes time. 

Better to install texlive-xetex instead, after that `make` command works which creates the pdf file.