### PR TITLE
kbleds: Replace magic with driver_name

### DIFF
--- a/examples/kbleds.c
+++ b/examples/kbleds.c
@@ -61,7 +61,7 @@ static int __init kbleds_init(void)
     pr_info("kbleds: finished scanning consoles\n");
 
     my_driver = vc_cons[fg_console].d->port.tty->driver;
-    pr_info("kbleds: tty driver magic %x\n", my_driver->magic);
+    pr_info("kbleds: tty driver name %s\n", my_driver->driver_name);
 
     /* Set up the LED blink timer the first time. */
     timer_setup(&my_timer, my_timer_func, 0);


### PR DESCRIPTION
Since the commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC") [1], the magic field no longer exists in the tty_driver. Instead of printing the magic field, use the driver_name field.

[1] https://lore.kernel.org/linux-doc/20220907231109.htnfxzmr6wkuhn2v@tarta.nabijaczleweli.xyz/

Close #216
Close #217