### PR TITLE
Update dependencies for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For Ubuntu Linux, macOS, and other Unix-like systems, run the following command(
 $ sudo apt install make texlive-full
 
 # Arch / Manjaro
-$ sudo pacman -S make texlive-most texlive-bin
+$ sudo pacman -S make texlive-binextra texlive-bin
 
 # macOS
 $ brew install mactex


### PR DESCRIPTION
From the [disscussion](https://bbs.archlinux.org/viewtopic.php?pid=2105974#p2105974), the `latexmk` has been moved to the `texlive-binextra` package.