### PR TITLE
Remove module * parameter from class_create()

### DIFF
--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -63,11 +63,11 @@ static int __init chardev_init(void)
 
     pr_info("I was assigned major number %d.\n", major);
 
-    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
     cls = class_create(DEVICE_NAME);
-    #else
+#else
     cls = class_create(THIS_MODULE, DEVICE_NAME);
-    #endif
+#endif
     device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);
 
     pr_info("Device created on /dev/%s\n", DEVICE_NAME);

--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -14,6 +14,7 @@
 #include <linux/printk.h>
 #include <linux/types.h>
 #include <linux/uaccess.h> /* for get_user and put_user */
+#include <linux/version.h>
 
 #include <asm/errno.h>
 
@@ -62,7 +63,11 @@ static int __init chardev_init(void)
 
     pr_info("I was assigned major number %d.\n", major);
 
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+    cls = class_create(DEVICE_NAME);
+    #else
     cls = class_create(THIS_MODULE, DEVICE_NAME);
+    #endif
     device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);
 
     pr_info("Device created on /dev/%s\n", DEVICE_NAME);


### PR DESCRIPTION
- From v6.4, class_create() does not have module *
  (See commit 11ba11 below)
- Added #ifdev for KERNEL_VERSION >= 6.4

From linux commit aaba11da9aa7d7d6b52a74d45b31cac118295a1
---------------------------------------------
driver core: class: remove module * from class_create()

The module pointer in class_create() never actually did anything,
and it shouldn't have been requred to be set as a parameter even
if it did something.  So just remove it and fix up all callers of the
function in the kernel tree at the same time.