### PR TITLE
Fix typo

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -383,7 +383,7 @@ The dash character will get converted to an underscore, so when you again try:
 sudo lsmod | grep hello
 \end{codebash}
 
-you should now see your loaded module. It can be removed again with:
+You should now see your loaded module. It can be removed again with:
 \begin{codebash}
 sudo rmmod hello_1
 \end{codebash}


### PR DESCRIPTION
Capitalized the first letter in a sentence.