### PR TITLE
Correct name/location for ioctl-number.rst

### DIFF
--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -13,7 +13,7 @@ struct ioctl_arg {
     unsigned int val;
 };
 
-/* Documentation/ioctl/ioctl-number.txt */
+/* Documentation/userspace-api/ioctl/ioctl-number.rst */
 #define IOC_MAGIC '\x66'
 
 #define IOCTL_VALSET _IOW(IOC_MAGIC, 0, struct ioctl_arg)


### PR DESCRIPTION
ioctl-number.rst in Documentation has been renamed and moved since v5.10

See commits
- 049500715e7
- 08536105d93