### PR TITLE
CI: Fix "unreplaced" warnings by using git source

### DIFF
--- a/.ci/static-analysis.sh
+++ b/.ci/static-analysis.sh
@@ -36,13 +36,12 @@ function do_cppcheck()
 
 function do_sparse()
 {
-    wget -q http://www.kernel.org/pub/software/devel/sparse/dist/sparse-latest.tar.gz
+    git clone git://git.kernel.org/pub/scm/devel/sparse/sparse.git --depth=1
     if [ $? -ne 0 ]; then
         echo "Failed to download sparse."
         exit 1
     fi
-    tar -xzf sparse-latest.tar.gz
-    pushd sparse-*/
+    pushd sparse
     make sparse || exit 1
     sudo make INST_PROGRAMS=sparse PREFIX=/usr install || exit 1
     popd


### PR DESCRIPTION
Because of sparse-latest.tar.gz has not been updated since 06-Sep-2021, we are encoutering an old bug, 0e1aae55e49c ("fix "unreplaced" warnings caused by using typeof() on inline functions") [1], that has been fixed in the newest version. So, let's switch to the git source tree [2] instead of using sparse-latest.tar.gz [3].

[1] https://git.kernel.org/pub/scm/devel/sparse/sparse.git/commit/?id=0e1aae55e49cad7ea43848af5b58ff0f57e7af99
[2] git://git.kernel.org/pub/scm/devel/sparse/sparse.git
[3] http://www.kernel.org/pub/software/devel/sparse/dist/sparse-latest.tar.gz