### PR TITLE
Move kallsyms_lookup_name inside HAVE_KPROBES

### DIFF
--- a/examples/syscall.c
+++ b/examples/syscall.c
@@ -178,9 +178,11 @@ static unsigned long **acquire_sys_call_table(void)
         return NULL;
     kallsyms_lookup_name = (unsigned long (*)(const char *name))kp.addr;
     unregister_kprobe(&kp);
-#endif
 
     return (unsigned long **)kallsyms_lookup_name("sys_call_table");
+#endif
+
+    return NULL;
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)


### PR DESCRIPTION
Draft PR looking for feedback.

kallsyms_lookup_name is defined inside #ifdef HAVE_KPROBES. Return call with kallsyms_lookup_name is outside the ifdef. Move kallsyms_lookup_name call inside the ifdef where the definition is.

Add a return NULL; call in the end, even though control might not reach there.