### PR TITLE
Add newline to last pr_info to force dmesg to flush

### DIFF
--- a/examples/example_atomic.c
+++ b/examples/example_atomic.c
@@ -50,7 +50,7 @@ static void atomic_bitwise(void)
     pr_info("Bits 4: " BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(word));
 
     word = 255;
-    pr_info("Bits 5: " BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(word));
+    pr_info("Bits 5: " BYTE_TO_BINARY_PATTERN "\n", BYTE_TO_BINARY(word));
 }
 
 static int __init example_atomic_init(void)


### PR DESCRIPTION
dmesg only flushes when it encounter a newline. Without a newline, the line is held in memory pending another printk. In this particular example (example_atomic.c), the last pr_info in atomic_bitwise() prints when another printk happens (either by another module, or __exit for this module.

This can be confusing to new learner. This patch adds a newline to the last pr_info forcing dmesg to print to the screen when the module is loaded.

--------------- Alternate solution ---------------
Alternate solutions could be adding a newline to BYTE_TO_BINARY_PATTERN
#define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c\n"

... or adding a newline to each pr_info() call.
