### PR TITLE
Replace schedule_work with queue_work

### DIFF
--- a/examples/sched.c
+++ b/examples/sched.c
@@ -17,7 +17,7 @@ static int __init sched_init(void)
 {
     queue = alloc_workqueue("HELLOWORLD", WQ_UNBOUND, 1);
     INIT_WORK(&work, work_handler);
-    schedule_work(&work);
+    queue_work(queue, &work);
     return 0;
 }
 


### PR DESCRIPTION
schedule_work adds work to global workqueue. In this example, we create a local workqueue. Use the local workqueue by calling queue_work(), instead of putting work on the global workqueue.