### PR TITLE
Fix typo in examples' comments

### DIFF
--- a/examples/bottomhalf.c
+++ b/examples/bottomhalf.c
@@ -15,7 +15,7 @@
 #include <linux/printk.h>
 #include <linux/init.h>
 
-/* Macro DECLARE_TASKLET_OLD exists for compatibiity.
+/* Macro DECLARE_TASKLET_OLD exists for compatibility.
  * See https://lwn.net/Articles/830964/
  */
 #ifndef DECLARE_TASKLET_OLD

--- a/examples/procfs4.c
+++ b/examples/procfs4.c
@@ -36,7 +36,7 @@ static void *my_seq_start(struct seq_file *s, loff_t *pos)
 }
 
 /* This function is called after the beginning of a sequence.
- * It is called untill the return is NULL (this ends the sequence).
+ * It is called until the return is NULL (this ends the sequence).
  */
 static void *my_seq_next(struct seq_file *s, void *v, loff_t *pos)
 {


### PR DESCRIPTION
Change 'untill' to 'until' in a comment.
Change 'compatibiity' to 'compatibility' in a comment.