### PR TITLE
Fix switch-case condition error in sample code

### DIFF
--- a/examples/cryptosk.c
+++ b/examples/cryptosk.c
@@ -46,7 +46,8 @@ static int test_skcipher_result(struct skcipher_def *sk, int rc)
     switch (rc) {
     case 0:
         break;
-    case -EINPROGRESS || -EBUSY:
+    case -EINPROGRESS:
+    case -EBUSY:
         rc = wait_for_completion_interruptible(&sk->result.completion);
         if (!rc && !sk->result.err) {
             reinit_completion(&sk->result.completion);


### PR DESCRIPTION
The code `case -EINPROGRESS || -EBUSY: ` is the same as `case -115 || -16 :` at compiler time, as both error code are implemented with macro like `#define EBUSY 16`. 

The code above is essentially the same as `case 1:`. In C, there is no real boolean value. Bool-like value will be converted to 1 or 0.

It does not matter too much if the `-EINPROGRESS || -EBUSY` is calculated at build time or at runtime. In both case, it will compare the `rc` with `1` in the switch expression. It will not compare the `rc` with any real error code number. When the code is really `-EBUSY`, the execution will fallback to the default branch.

And in practice, most of the compilers will do this simple compile-time static calculation, and generate code like 
```
static int test_skcipher_result(struct skcipher_def *sk, int rc)
{
    switch (rc) {
    case 0:
        break;
    case 1:
        rc = wait_for_completion_interruptible(&sk->result.completion);
/* code removed for conciseness */
        break;
    default:
        pr_info("skcipher encrypt returned with %d result %d\n", rc,
                sk->result.err);
        break;
    }
    init_completion(&sk->result.completion);
    return rc;
}

```