### PR TITLE
Change occurrences of egrep to grep -E

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|cc|c|h)\$")
+SOURCES=$(find $(git rev-parse --show-toplevel) | grep -E "\.(cpp|cc|c|h)\$")
 
 CLANG_FORMAT=$(which clang-format-12)
 if [ $? -ne 0 ]; then
@@ -18,4 +18,4 @@ do
     $CLANG_FORMAT ${file} > expected-format
     diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
 done
-exit $($CLANG_FORMAT --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit $($CLANG_FORMAT --output-replacements-xml ${SOURCES} | grep -E -c "</replacement>")

--- a/.ci/static-analysis.sh
+++ b/.ci/static-analysis.sh
@@ -2,7 +2,7 @@
 
 function do_cppcheck()
 {
-    local SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|cc|c|h)\$")
+    local SOURCES=$(find $(git rev-parse --show-toplevel) | grep -E "\.(cpp|cc|c|h)\$")
 
     local CPPCHECK=$(which cppcheck)
     if [ $? -ne 0 ]; then
@@ -25,7 +25,7 @@ function do_cppcheck()
             --std=c89 "
 
     $CPPCHECK $OPTS --xml ${SOURCES} 2> cppcheck.xml
-    local ERROR_COUNT=$(cat cppcheck.xml | egrep -c "</error>" )
+    local ERROR_COUNT=$(cat cppcheck.xml | grep -E -c "</error>" )
 
     if [ $ERROR_COUNT -gt 0 ]; then
         echo "Cppcheck failed: $ERROR_COUNT error(s)"
@@ -49,8 +49,8 @@ function do_sparse()
 
     make -C examples C=2 CHECK="$SPARSE" 2> sparse.log
 
-    local WARNING_COUNT=$(cat sparse.log | egrep -c " warning:" )
-    local ERROR_COUNT=$(cat sparse.log | egrep -c " error:" )
+    local WARNING_COUNT=$(cat sparse.log | grep -E -c " warning:" )
+    local ERROR_COUNT=$(cat sparse.log | grep -E -c " error:" )
     local COUNT=`expr $WARNING_COUNT + $ERROR_COUNT`
     if [ $COUNT -gt 0 ]; then
         echo "Sparse failed: $WARNING_COUNT warning(s), $ERROR_COUNT error(s)"
@@ -70,8 +70,8 @@ function do_gcc()
 
     make -C examples CONFIG_STATUS_CHECK_GCC=y STATUS_CHECK_GCC=$GCC 2> gcc.log
 
-    local WARNING_COUNT=$(cat gcc.log | egrep -c " warning:" )
-    local ERROR_COUNT=$(cat gcc.log | egrep -c " error:" )
+    local WARNING_COUNT=$(cat gcc.log | grep -E -c " warning:" )
+    local ERROR_COUNT=$(cat gcc.log | grep -E -c " error:" )
     local COUNT=`expr $WARNING_COUNT + $ERROR_COUNT`
     if [ $COUNT -gt 0 ]; then
         echo "gcc failed: $WARNING_COUNT warning(s), $ERROR_COUNT error(s)"


### PR DESCRIPTION
A lot of distributions are emitting warnings when using egrep and fgrep since these are deprecated.

Update occurrences of egrep to 'grep -E' keeping the same functionality and making the code more portable without emitting warnings.