### PR TITLE
Describe atomic context in spinlock section

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1695,13 +1695,13 @@ Holding a spinlock is one of those situations.
 Sleeping in atomic contexts may leave the system hanging, as the occupied CPU devotes 100\% of its resources doing nothing but sleeping.
 In some worse cases the system may crash.
 Thus, sleeping in atomic contexts is considered a bug in the kernel.
-They are sometimes called "sleep-in-atomic-context" in some materials.
+They are sometimes called ``sleep-in-atomic-context'' in some materials.
 
 Note that sleeping here is not limited to calling the sleep functions explicitly.
 If subsequent function calls eventually invoke a function that sleeps, it is also considered sleeping.
 Thus, it is important to pay attention to functions being used in atomic context.
 There's no documentation recording all such functions, but code comments may help.
-Sometimes you may find comments in kernel source code stating that a function "may sleep", "might sleep", or more explicitly "the caller should not hold a spinlock".
+Sometimes you may find comments in kernel source code stating that a function ``may sleep'', ``might sleep'', or more explicitly ``the caller should not hold a spinlock''.
 Those comments are hints that a function may implicitly sleep and must not be called in atomic contexts.
 
 \subsection{Read and write locks}


### PR DESCRIPTION
Aquiring a spinlock makes the holder enter atomic context. Extra attention is needed in atomic context. In particular, functions that may sleep must not be used. Add this detail to the spinlock section.