### PR TITLE
Rework the threaded IRQ examples

### DIFF
--- a/examples/bh_threaded.c
+++ b/examples/bh_threaded.c
@@ -81,7 +81,7 @@ static int __init bottomhalf_init(void)
 
     ret = request_threaded_irq(
         button_irqs[0], button_top_half, button_bottom_half,
-        IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "gpiomod#button1", NULL);
+        IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "gpiomod#button1", &buttons[0]);
 
     if (ret) {
         pr_err("Unable to request IRQ: %d\n", ret);
@@ -101,7 +101,7 @@ static int __init bottomhalf_init(void)
 
     ret = request_threaded_irq(
         button_irqs[1], button_top_half, button_bottom_half,
-        IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "gpiomod#button2", NULL);
+        IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "gpiomod#button2", &buttons[1]);
 
     if (ret) {
         pr_err("Unable to request IRQ: %d\n", ret);

--- a/examples/bh_threaded.c
+++ b/examples/bh_threaded.c
@@ -80,7 +80,7 @@ static int __init bottomhalf_init(void)
     pr_info("Successfully requested BUTTON1 IRQ # %d\n", button_irqs[0]);
 
     ret = request_threaded_irq(
-        gpio_to_irq(button_irqs[0]), button_top_half, button_bottom_half,
+        button_irqs[0], button_top_half, button_bottom_half,
         IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "gpiomod#button1", NULL);
 
     if (ret) {
@@ -100,7 +100,7 @@ static int __init bottomhalf_init(void)
     pr_info("Successfully requested BUTTON2 IRQ # %d\n", button_irqs[1]);
 
     ret = request_threaded_irq(
-        gpio_to_irq(button_irqs[1]), button_top_half, button_bottom_half,
+        button_irqs[1], button_top_half, button_bottom_half,
         IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "gpiomod#button2", NULL);
 
     if (ret) {

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1673,10 +1673,36 @@ The example below modifies the previous example to also run an additional task w
 
 \samplec{examples/bottomhalf.c}
 
-It is expected that at some unspecified point in the future tasklets may eventually be deprecated, to be replaced by \textit{threaded irqs} instead.
+\subsection{Threaded IRQ}
+
+Threaded IRQ is a mechanism to handle both top-half and bottom-half of an IRQ at once.
+A threaded IRQ splits one handler into two: one for the top-half, the other for the bottom-half.
+Those two handlers are registered at once by \cpp|request_threaded_irq()|.
+
+The top-half handler runs in interrupt context.
+It's the equivalence of the handler passed to the \cpp|request_irq()|.
+The bottom-half handler on the other hand runs in its own thread.
+This thread is created on registration of a threaded IRQ. Its sole purpose is to run this bottom-half handler.
+This is where a threaded IRQ is ``threaded''.
+
+Whether the bottom-half handler will be invoked is determined by the return value of the top-half handler.
+If \cpp|IRQ_WAKE_THREAD| is returned, that bottom-half serving thread will wake up.
+The thread then runs the bottom-half handler.
+
 Here is an example of how to do the same thing as before, with top and bottom halves, but using threads.
 
 \samplec{examples/bh_threaded.c}
+
+\cpp|request_threaded_irq()| only takes one additional parameter than the \cpp|request_irq()| -- the bottom-half handling function that runs in its own thread.
+In this example it is the \cpp|button_bottom_half()|.
+Usage of other parameters are the same as \cpp|request_irq()|.
+
+Presence of both handlers is not mandatory.
+If either of them is not needed, pass the \cpp|NULL| instead.
+A \cpp|NULL| top-half handler implicitly means doing nothing but waking up the bottom-half serving thread; A \cpp|NULL| bottom-half handler will have the same effect as \cpp|request_irq()|.
+In fact, this is how \cpp|request_irq()| is implemented.
+
+Note that passing \cpp|NULL| as both handlers is considered an error and will make registration fail.
 
 \section{Crypto}
 \label{sec:crypto}

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1675,34 +1675,36 @@ The example below modifies the previous example to also run an additional task w
 
 \subsection{Threaded IRQ}
 
-Threaded IRQ is a mechanism to handle both top-half and bottom-half of an IRQ at once.
-A threaded IRQ splits one handler into two: one for the top-half, the other for the bottom-half.
-Those two handlers are registered at once by \cpp|request_threaded_irq()|.
+Threaded IRQ is a mechanism to organize both top-half and bottom-half of an IRQ at once.
+A threaded IRQ splits the one handler in \cpp|request_irq()| into two: one for the top-half, the other for the bottom-half.
+The \cpp|request_threaded_irq()| is the function for using threaded IRQs.
+Two handlers are registered at once in the \cpp|request_threaded_irq()|.
 
+Those two handlers run in different context.
 The top-half handler runs in interrupt context.
 It's the equivalence of the handler passed to the \cpp|request_irq()|.
 The bottom-half handler on the other hand runs in its own thread.
-This thread is created on registration of a threaded IRQ. Its sole purpose is to run this bottom-half handler.
+This thread is created on registration of a threaded IRQ.
+Its sole purpose is to run this bottom-half handler.
 This is where a threaded IRQ is ``threaded''.
-
-Whether the bottom-half handler will be invoked is determined by the return value of the top-half handler.
-If \cpp|IRQ_WAKE_THREAD| is returned, that bottom-half serving thread will wake up.
+If \cpp|IRQ_WAKE_THREAD| is returned by the top-half handler, that bottom-half serving thread will wake up.
 The thread then runs the bottom-half handler.
 
 Here is an example of how to do the same thing as before, with top and bottom halves, but using threads.
 
 \samplec{examples/bh_threaded.c}
 
-\cpp|request_threaded_irq()| only takes one additional parameter than the \cpp|request_irq()| -- the bottom-half handling function that runs in its own thread.
+A threaded IRQ is registered using \cpp|request_threaded_irq()|.
+This function only takes one additional parameter than the \cpp|request_irq()| -- the bottom-half handling function that runs in its own thread.
 In this example it is the \cpp|button_bottom_half()|.
 Usage of other parameters are the same as \cpp|request_irq()|.
 
 Presence of both handlers is not mandatory.
 If either of them is not needed, pass the \cpp|NULL| instead.
-A \cpp|NULL| top-half handler implicitly means doing nothing but waking up the bottom-half serving thread; A \cpp|NULL| bottom-half handler will have the same effect as \cpp|request_irq()|.
+A \cpp|NULL| top-half handler implicitly means doing nothing but waking up the bottom-half serving thread (for running the bottom-half handler); A \cpp|NULL| bottom-half handler would have the same effect as if \cpp|request_irq()| were used.
 In fact, this is how \cpp|request_irq()| is implemented.
 
-Note that passing \cpp|NULL| as both handlers is considered an error and will make registration fail.
+Note that passing \cpp|NULL| to both handlers is considered an error and will make registration fail.
 
 \section{Crypto}
 \label{sec:crypto}

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1701,7 +1701,8 @@ Usage of other parameters are the same as \cpp|request_irq()|.
 
 Presence of both handlers is not mandatory.
 If either of them is not needed, pass the \cpp|NULL| instead.
-A \cpp|NULL| top-half handler implicitly means doing nothing but waking up the bottom-half serving thread (for running the bottom-half handler); A \cpp|NULL| bottom-half handler would have the same effect as if \cpp|request_irq()| were used.
+A \cpp|NULL| top-half handler implies that no action is taken except to wake up the bottom-half serving thread, which runs the bottom-half handler.
+Similarly, a \cpp|NULL| bottom-half handler effectively acts as if \cpp|request_irq()| were used.
 In fact, this is how \cpp|request_irq()| is implemented.
 
 Note that passing \cpp|NULL| to both handlers is considered an error and will make registration fail.


### PR DESCRIPTION
Rework descriptions for threaded IRQ, making it a section of its own. Also, fix errors in the `bh_threaded.c` example. 