### PR TITLE
Improve readibility

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -708,7 +708,7 @@ Now you can turn back to the directory of your module and compile it: It will be
 \section{Preliminaries}
 \subsection{How modules begin and end}
 \label{sec:module_init_exit}
-A typical program starts with a |main()| function, executes a series of instructions,
+A typical program starts with a \cpp|main()| function, executes a series of instructions,
 and terminates after completing these instructions.
 Kernel modules, however, follow a different pattern.
 A module always begins with either the \cpp|init_module| function or a function designated by the \cpp|module_init| call.


### PR DESCRIPTION
Add `\cpp` before |main()| to improve readibility so that it won't look like "|main()|" in the paragraph.