### PR TITLE
vinput: Fix multiple issue

### DIFF
--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -106,7 +106,7 @@ static ssize_t vinput_read(struct file *file, char __user *buffer, size_t count,
         count = len - *offset;
 
     if (raw_copy_to_user(buffer, buff + *offset, count))
-        count = -EFAULT;
+        return -EFAULT;
 
     *offset += count;
 

--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -179,8 +179,6 @@ static struct vinput *vinput_alloc_vdevice(void)
 
     try_module_get(THIS_MODULE);
 
-    memset(vinput, 0, sizeof(struct vinput));
-
     spin_lock_init(&vinput->lock);
 
     spin_lock(&vinput_lock);

--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -177,6 +177,11 @@ static struct vinput *vinput_alloc_vdevice(void)
     int err;
     struct vinput *vinput = kzalloc(sizeof(struct vinput), GFP_KERNEL);
 
+    if (!vinput) {
+        pr_err("vinput: Cannot allocate vinput input device\n");
+        return ERR_PTR(-ENOMEM);
+    }
+
     try_module_get(THIS_MODULE);
 
     spin_lock_init(&vinput->lock);


### PR DESCRIPTION
Fix multiple issues for vinput module:

1. Removes redundant memset calls that were unnecessary since memory allocated with kzalloc is already zeroed due to the __GFP_ZERO gfp flag.
2. Fixes a NULL pointer dereference caused by failed kzalloc allocation. It adds a check for the return value of kzalloc and handles failed allocations by printing an error message and returning ERR_PTR(-ENOMEM).
3. Corrects the handling of failures in raw_copy_to_user() in vinput_read(). Previously, the function would modify '*offset' incorrectly on raw_copy_to_user() failure. Fix this behavior by changing count = -EFAULT to return -EFAULT instead.