### PR TITLE
docs: Update example in chapter 8 to use sudo

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1347,14 +1347,14 @@ sudo lsmod | grep hello_sysfs
 What is the current value of \cpp|myvariable| ?
 
 \begin{codebash}
-cat /sys/kernel/mymodule/myvariable
+sudo cat /sys/kernel/mymodule/myvariable
 \end{codebash}
 
 Set the value of \cpp|myvariable| and check that it changed.
 
 \begin{codebash}
-echo "32" > /sys/kernel/mymodule/myvariable
-cat /sys/kernel/mymodule/myvariable
+echo "32" | sudo tee /sys/kernel/mymodule/myvariable
+sudo cat /sys/kernel/mymodule/myvariable
 \end{codebash}
 
 Finally, remove the test module:


### PR DESCRIPTION
In chapter 8, the example code for setting permissions is as follows:
```c
static struct kobj_attribute myvariable_attribute =
    __ATTR(myvariable, 0660, myvariable_show, (void *)myvariable_store);
```
We have two options:
1. Instruct users to access the file with `sudo`.
2. Relax the permission setting to 0666.

This commit adopts the sudo method to maintain security constraints.