### PR TITLE
Remove the redundant code

### DIFF
--- a/examples/procfs1.c
+++ b/examples/procfs1.c
@@ -48,7 +48,6 @@ static int __init procfs1_init(void)
 {
     our_proc_file = proc_create(procfs_name, 0644, NULL, &proc_file_fops);
     if (NULL == our_proc_file) {
-        proc_remove(our_proc_file);
         pr_alert("Error:Could not initialize /proc/%s\n", procfs_name);
         return -ENOMEM;
     }


### PR DESCRIPTION
proc_remove does nothing when the argument is NULL[1]. We don't need proc_remove after proc_create failed.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/proc/generic.c#n789