### PR TITLE
Fix a wierd behavior of a function

### DIFF
--- a/examples/procfs2.c
+++ b/examples/procfs2.c
@@ -48,13 +48,13 @@ static ssize_t procfile_write(struct file *file, const char __user *buff,
                               size_t len, loff_t *off)
 {
     procfs_buffer_size = len;
-    if (procfs_buffer_size > PROCFS_MAX_SIZE)
-        procfs_buffer_size = PROCFS_MAX_SIZE;
+    if (procfs_buffer_size >= PROCFS_MAX_SIZE)
+        procfs_buffer_size = PROCFS_MAX_SIZE - 1;
 
     if (copy_from_user(procfs_buffer, buff, procfs_buffer_size))
         return -EFAULT;
 
-    procfs_buffer[procfs_buffer_size & (PROCFS_MAX_SIZE - 1)] = '\0';
+    procfs_buffer[procfs_buffer_size] = '\0';
     *off += procfs_buffer_size;
     pr_info("procfile write %s\n", procfs_buffer);
 


### PR DESCRIPTION
The procfile_write prints the content what user writes into. However, when the content size is greater than or equal to PROCFS_MAX_SIZE, procfile_write will print nothing, because the index for appending the tail NULL character will be modulo to 0.

So, I modify the code with 1. restrict the max acceptable content size to (PROCFS_MAX_SIZE - 1), left a space for NULL character 2. discard the modulo because we already restrict the max size to (PROCFS_MAX_SIZE - 1)