### PR TITLE
Remove the redundant code

### DIFF
--- a/examples/hello-sysfs.c
+++ b/examples/hello-sysfs.c
@@ -23,7 +23,7 @@ static ssize_t myvariable_store(struct kobject *kobj,
                                 struct kobj_attribute *attr, char *buf,
                                 size_t count)
 {
-    sscanf(buf, "%du", &myvariable);
+    sscanf(buf, "%d", &myvariable);
     return count;
 }
 


### PR DESCRIPTION
As myvariable is declared as an integer, it is meaningless that putting u after %d in the format specifier of sscanf for scanning an integer. This patch removes the u in the format specifier for avoiding misleading.