### PR TITLE
Fix incorrect failure handling in vinput_init

### DIFF
--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -401,7 +401,7 @@ static int __init vinput_init(void)
 
     return 0;
 failed_class:
-    class_unregister(&vinput_class);
+    unregister_chrdev(vinput_dev, DRIVER_NAME);
 failed_alloc:
     return err;
 }


### PR DESCRIPTION
After class_register failure, the wrong function class_unregister was used. The correct cleanup function should be unregister_chrdev, as register_chrdev was used before class_register.