### PR TITLE
Fix potential reference count leak in vinput

### DIFF
--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -284,6 +284,8 @@ static ssize_t export_store(struct class *class, struct class_attribute *attr,
 
 fail_register_vinput:
     device_unregister(&vinput->dev);
+    /* avoid calling vinput_destroy_vdevice() twice */
+    return err;
 fail_register:
     vinput_destroy_vdevice(vinput);
 fail:


### PR DESCRIPTION
In the export_store function, when vinput_register_vdevice fails, the current error handling process calls device_unregister followed by vinput_destroy_vdevice. However, the device_unregister here triggers its release function, which already includes a call to vinput_destroy_vdevice. As a result, vinput_destroy_vdevice is called twice. Since vinput_destroy_vdevice contains module_put, this double call must be avoided to prevent potential reference count issues.