### PR TITLE
Fix potential memory leak in vinput

### DIFF
--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -283,10 +283,12 @@ static ssize_t export_store(struct class *class, struct class_attribute *attr,
     return len;
 
 fail_register_vinput:
+    input_free_device(vinput->input);
     device_unregister(&vinput->dev);
     /* avoid calling vinput_destroy_vdevice() twice */
     return err;
 fail_register:
+    input_free_device(vinput->input);
     vinput_destroy_vdevice(vinput);
 fail:
     return err;


### PR DESCRIPTION
In the export_store function, the error handling paths followed a successful vinput_alloc_vdevice call are missing a corresponding input_free_device call. Since vinput_alloc_vdevice internally calls input_allocate_device, and input_register_device has not been called yet, input_free_device should be used to properly free the allocated input_device struct in this scenario[1].

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/input/input.c#n2094