### PR TITLE
Fix missing function call in error handling path

### DIFF
--- a/examples/hello-sysfs.c
+++ b/examples/hello-sysfs.c
@@ -42,6 +42,7 @@ static int __init mymodule_init(void)
 
     error = sysfs_create_file(mymodule, &myvariable_attribute.attr);
     if (error) {
+        kobject_put(mymodule);
         pr_info("failed to create the myvariable file "
                 "in /sys/kernel/mymodule\n");
     }


### PR DESCRIPTION
Previously, the code did not call kobject_put when sysfs_create_file
failed, leading to a potential memory leak. This commit adds the missing
kobject_put to ensure proper resource cleanup.