### PR TITLE
CI: Skip style with Cppcheck

### DIFF
--- a/.ci/non-working
+++ b/.ci/non-working
@@ -2,3 +2,4 @@ bottomhalf
 bh_threaded
 intrpt
 vkbd
+syscall-steal

--- a/.ci/static-analysis.sh
+++ b/.ci/static-analysis.sh
@@ -19,7 +19,7 @@ function do_cppcheck()
     # - [*.c] missingIncludeSystem: Focus on the example code, not the kernel headers.
 
     local OPTS="
-            --enable=warning,style,performance,information
+            --enable=warning,performance,information
             --suppress=unusedFunction:hello-1.c
             --suppress=missingIncludeSystem
             --std=c89 "

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
                 github.event_name == 'workflow_dispatch' }}
         run: |
-            sudo apt install -q -y clang-format cppcheck gcc
+            sudo apt install -q -y clang-format cppcheck gcc libsqlite3-dev
             .ci/check-newline.sh
             .ci/check-format.sh
             .ci/static-analysis.sh


### PR DESCRIPTION
For callback functions, we may not expect to changes their prototypes, and this commit skips the corresponding checks.