### PR TITLE
Allow devicemodel built with Linux v6.11+

### DIFF
--- a/examples/devicemodel.c
+++ b/examples/devicemodel.c
@@ -4,6 +4,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
+#include <linux/version.h>
 
 struct devicemodel_data {
     char *greeting;
@@ -22,14 +23,18 @@ static int devicemodel_probe(struct platform_device *dev)
 
     return 0;
 }
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int devicemodel_remove(struct platform_device *dev)
+#else
+static void devicemodel_remove(struct platform_device *dev)
+#endif
 {
     pr_info("devicemodel example removed\n");
 
     /* Your device removal code */
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static int devicemodel_suspend(struct device *dev)


### PR DESCRIPTION
Since commit 0edb555 ("platform: Make platform_driver::remove() return void"), the original `platform_driver::remove()` function returned an integer value, usually an error code. This made driver developers think that errors were properly handled. However, the driver core does not stop the device removal process based on the error code, so the error code did not serve its intended purpose. Therefore, the return type was changed to `void` to avoid potential issues.

Make the devicemodel example run successfully on Linux v6.11+.