### PR TITLE
Fix a typo

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -447,7 +447,7 @@ What happens?
 \label{hello_n_goodbye}
 In early kernel versions you had to use the \cpp|init_module| and \cpp|cleanup_module| functions, as in the first hello world example, but these days you can name those anything you want by using the \cpp|module_init| and \cpp|module_exit| macros.
 These macros are defined in \src{include/linux/module.h}.
-The only requirement is that your init and cleanup functions must be defined before calling the those macros, otherwise you'll get compilation errors.
+The only requirement is that your init and cleanup functions must be defined before calling those macros, otherwise you'll get compilation errors.
 Here is an example of this technique:
 
 \samplec{examples/hello-2.c}


### PR DESCRIPTION
There is an extra "the", remove it. 
 <div id='description'>
<h3>Summary by Bito</h3>
Documentation improvement in the Linux Kernel Module Programming Guide, specifically addressing grammatical clarity by removing a redundant article 'the' in the explanation of init and cleanup function definitions.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>