### PR TITLE
Remove redundant code

### DIFF
--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -25,7 +25,6 @@ static ssize_t device_read(struct file *, char __user *, size_t, loff_t *);
 static ssize_t device_write(struct file *, const char __user *, size_t,
                             loff_t *);
 
-#define SUCCESS 0
 #define DEVICE_NAME "chardev" /* Dev name as it appears in /proc/devices   */
 #define BUF_LEN 80 /* Max length of the message from the device */
 
@@ -72,7 +71,7 @@ static int __init chardev_init(void)
 
     pr_info("Device created on /dev/%s\n", DEVICE_NAME);
 
-    return SUCCESS;
+    return 0;
 }
 
 static void __exit chardev_exit(void)
@@ -99,7 +98,7 @@ static int device_open(struct inode *inode, struct file *file)
     sprintf(msg, "I already told you %d times Hello world!\n", counter++);
     try_module_get(THIS_MODULE);
 
-    return SUCCESS;
+    return 0;
 }
 
 /* Called when a process closes the device file. */
@@ -113,7 +112,7 @@ static int device_release(struct inode *inode, struct file *file)
      */
     module_put(THIS_MODULE);
 
-    return SUCCESS;
+    return 0;
 }
 
 /* Called when a process, which already opened the dev file, attempts to

--- a/examples/chardev2.c
+++ b/examples/chardev2.c
@@ -17,7 +17,6 @@
 #include <asm/errno.h>
 
 #include "chardev.h"
-#define SUCCESS 0
 #define DEVICE_NAME "char_dev"
 #define BUF_LEN 80
 
@@ -42,7 +41,7 @@ static int device_open(struct inode *inode, struct file *file)
     pr_info("device_open(%p)\n", file);
 
     try_module_get(THIS_MODULE);
-    return SUCCESS;
+    return 0;
 }
 
 static int device_release(struct inode *inode, struct file *file)
@@ -50,7 +49,7 @@ static int device_release(struct inode *inode, struct file *file)
     pr_info("device_release(%p,%p)\n", inode, file);
 
     module_put(THIS_MODULE);
-    return SUCCESS;
+    return 0;
 }
 
 /* This function is called whenever a process which has already opened the
@@ -126,7 +125,7 @@ device_ioctl(struct file *file, /* ditto */
              unsigned long ioctl_param)
 {
     int i;
-    long ret = SUCCESS;
+    long ret = 0;
 
     /* We don't want to talk to two processes at the same time. */
     if (atomic_cmpxchg(&already_open, CDEV_NOT_USED, CDEV_EXCLUSIVE_OPEN))

--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -22,7 +22,6 @@ static ssize_t device_read(struct file *file, char __user *buf, size_t count,
 static ssize_t device_write(struct file *file, const char __user *buf,
                             size_t count, loff_t *ppos);
 
-#define SUCCESS 0
 #define DEVICE_NAME "key_state"
 #define BUF_LEN 10
 
@@ -71,7 +70,7 @@ static int __init chardev_init(void)
 
     pr_info("Device created on /dev/%s\n", DEVICE_NAME);
 
-    return SUCCESS;
+    return 0;
 }
 
 static void __exit chardev_exit(void)
@@ -103,7 +102,7 @@ static int device_open(struct inode *inode, struct file *file)
 
     try_module_get(THIS_MODULE);
 
-    return SUCCESS;
+    return 0;
 }
 
 /**
@@ -120,7 +119,7 @@ static int device_release(struct inode *inode, struct file *file)
      */
     module_put(THIS_MODULE);
 
-    return SUCCESS;
+    return 0;
 }
 
 /**


### PR DESCRIPTION
Remove unnecessary definition of SUCCESS, as returning 0 already indicates successful execution. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances code clarity by removing redundant definitions of SUCCESS across three files and replacing them with 0. This simplification contributes to a cleaner and more maintainable codebase.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>