### PR TITLE
Fix grammar in IRQ flag usage description

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1983,7 +1983,7 @@ This function receives the IRQ number, the name of the function, flags, a name f
 Usually there is a certain number of IRQs available.
 How many IRQs there are is hardware-dependent.
 
-The flags can be used for specify behaviors of the IRQ.
+The flags can be used to specify behaviors of the IRQ.
 For example, use \cpp|IRQF_SHARED| to indicate you are willing to share the IRQ with other interrupt handlers (usually because a number of hardware devices sit on the same IRQ); use the \cpp|IRQF_ONESHOT| to indicate that the IRQ is not reenabled after the handler finished.
 It should be noted that in some materials, you may encounter another set of IRQ flags named with the \cpp|SA| prefix.
 For example, the \cpp|SA_SHIRQ| and the \cpp|SA_INTERRUPT|.


### PR DESCRIPTION
Replaced "for specify" with "to specify" in the explanation of IRQ flags. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request corrects a grammatical error in the documentation regarding IRQ flags, changing 'for specify' to 'to specify'. This enhancement improves the clarity and accuracy of the documentation.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>