### PR TITLE
Fix formatting of `unsigned int major`

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1024,7 +1024,7 @@ You do this by using the \cpp|register_chrdev| function, defined by \src{include
 int register_chrdev(unsigned int major, const char *name, struct file_operations *fops);
 \end{code}
 
-Where unsigned int major is the major number you want to request, \cpp|const char *name| is the name of the device as it will appear in \verb|/proc/devices| and \cpp|struct file_operations *fops| is a pointer to the \cpp|file_operations| table for your driver.
+Where \cpp|unsigned int major| is the major number you want to request, \cpp|const char *name| is the name of the device as it will appear in \verb|/proc/devices| and \cpp|struct file_operations *fops| is a pointer to the \cpp|file_operations| table for your driver.
 A negative return value means the registration failed. Note that we didn't pass the minor number to \cpp|register_chrdev|.
 That is because the kernel doesn't care about the minor number; only our driver uses it.
 


### PR DESCRIPTION
Wrap the type and name in `\cpp|...| `for consistency with other parameters in the sentence. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the documentation by improving the formatting of the type 'unsigned int major', ensuring consistency with other parameters and enhancing readability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>