### PR TITLE
Update kernel header install command for clarity

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -210,7 +210,7 @@ apt-cache search linux-headers-`uname -r`
 The following command provides information on the available kernel header files.
 Then for example:
 \begin{codebash}
-sudo apt-get install kmod linux-headers-5.4.0-80-generic
+sudo apt-get install linux-headers-`uname -r`
 \end{codebash}
 
 On Arch Linux:


### PR DESCRIPTION
Remove the redundant `kmod` installation since it is already installed earlier. Also replace the hardcoded kernel version with `'uname -r'` to improve portability and compatibility with modern Linux distributions. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the kernel header installation documentation by eliminating the redundant `kmod` installation and using a dynamic command with `uname -r` instead of a hardcoded kernel version, improving clarity and compatibility. It also updates the installation documentation for better portability across Linux distributions.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>