### PR TITLE
Rephrase informal example in module section

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -769,7 +769,7 @@ The 2nd man section is devoted to system calls (like \cpp|kill()| and \cpp|read(
 The 3rd man section is devoted to library calls, which you would probably be more familiar with (like \cpp|cosh()| and \cpp|random()|).
 
 You can even write modules to replace the kernel's system calls, which we will do shortly.
-Crackers often make use of this sort of thing for backdoors or trojans, but you can write your own modules to do more benign things, like have the kernel write Tee hee, that tickles! every time someone tries to delete a file on your system.
+Crackers often make use of this sort of thing for backdoors or trojans, but you can write your own modules to do more benign things, like have the kernel log a message whenever someone attempts to delete a file on your system.
 
 \subsection{User Space vs Kernel Space}
 \label{sec:user_kernl_space}


### PR DESCRIPTION
Replaced the informal message with a formal description to improve
tone and maintain consistency in documentation. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances document readability and consistency in 'lkmpg.tex' by replacing raw inline messages with LaTeX-style double quotes and an informal example with a more formal description, ensuring correct rendering in generated documents and maintaining a professional standard.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>