### PR TITLE
Align version check

### DIFF
--- a/examples/devicemodel.c
+++ b/examples/devicemodel.c
@@ -23,10 +23,10 @@ static int devicemodel_probe(struct platform_device *dev)
 
     return 0;
 }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
-static int devicemodel_remove(struct platform_device *dev)
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
 static void devicemodel_remove(struct platform_device *dev)
+#else
+static int devicemodel_remove(struct platform_device *dev)
 #endif
 {
     pr_info("devicemodel example removed\n");

--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -60,10 +60,10 @@ static int __init chardev_init(void)
 
     pr_info("I was assigned major number %d\n", major);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-    cls = class_create(THIS_MODULE, DEVICE_NAME);
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
     cls = class_create(DEVICE_NAME);
+#else
+    cls = class_create(THIS_MODULE, DEVICE_NAME);
 #endif
 
     device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);

--- a/examples/syscall-steal.c
+++ b/examples/syscall-steal.c
@@ -30,16 +30,7 @@
 
 /* The in-kernel calls to the ksys_close() syscall were removed in Linux v5.11+.
  */
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0))
-
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 4, 0)
-#define HAVE_KSYS_CLOSE 1
-#include <linux/syscalls.h> /* For ksys_close() */
-#else
-#include <linux/kallsyms.h> /* For kallsyms_lookup_name */
-#endif
-
-#else
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0))
 
 #if defined(CONFIG_KPROBES)
 #define HAVE_KPROBES 1
@@ -64,7 +55,16 @@ static unsigned long sym = 0;
 module_param(sym, ulong, 0644);
 #endif /* CONFIG_KPROBES */
 
-#endif /* Version < v5.7 */
+#else
+
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 4, 0)
+#define HAVE_KSYS_CLOSE 1
+#include <linux/syscalls.h> /* For ksys_close() */
+#else
+#include <linux/kallsyms.h> /* For kallsyms_lookup_name */
+#endif
+
+#endif /* Version >= v5.7 */
 
 /* UID we want to spy on - will be filled from the command line. */
 static uid_t uid = -1;


### PR DESCRIPTION
The condition ">=" is used to align all version checks, improving code consistency and readability. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances code consistency and readability by aligning the version check for the class_create function in static_key.c with chardev.c and standardizing version checks across multiple files. The condition was modified from '<' to '>=', improving overall code quality, logical consistency, and maintainability across related files.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>