### PR TITLE
Fix grammar in virtual input device driver section

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -2055,7 +2055,7 @@ After that, registers it by calling \cpp|input_register_device()|.
 
 Here is an example, vinput,
 It is an API to allow easy development of virtual input drivers.
-The drivers needs to export a \cpp|vinput_device()| that contains the virtual device name and \cpp|vinput_ops| structure that describes:
+The driver needs to export a \cpp|vinput_device()| that contains the virtual device name and \cpp|vinput_ops| structure that describes:
 
 \begin{itemize}
     \item the init function: \cpp|init()|


### PR DESCRIPTION
Change "The drivers needs" to "The driver needs" to correct a subject-verb disagreement and improve readability. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request corrects a grammatical error in the documentation for the virtual input device driver section, improving clarity by changing 'The drivers needs' to 'The driver needs'. No other modifications were made.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>