### PR TITLE
Drop .owner for kernel >= 6.4

### DIFF
--- a/examples/led.c
+++ b/examples/led.c
@@ -81,7 +81,9 @@ static ssize_t device_write(struct file *file, const char __user *buffer,
 }
 
 static struct file_operations fops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .owner = THIS_MODULE,
+#endif
     .write = device_write,
     .open = device_open,
     .release = device_release,
@@ -112,7 +114,9 @@ static int __init led_init(void)
             MINOR(led_device.dev_num));
 
     /* Prevents module unloading while operations are in use */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     led_device.cdev.owner = THIS_MODULE;
+#endif
 
     cdev_init(&led_device.cdev, &fops);
     ret = cdev_add(&led_device.cdev, led_device.dev_num, 1);


### PR DESCRIPTION
Kernel 6.4+ sets .owner automatically. Remove manual assignment to avoid build issues and keep compatibility with older versions.

Reference : sysprog21/simrupt#12 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request updates the LED device driver for kernel compatibility by removing the manual assignment of the .owner field for kernel versions 6.4 and above, preventing build issues while ensuring adherence to new kernel standards.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>