### PR TITLE
Improve clarity in file access example

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1612,7 +1612,8 @@ The process does not know somebody else used the CPU for most of the time betwee
 It can then proceed to set a global variable to tell all the other processes that the file is still open and go on with its life.
 When the other processes get a piece of the CPU, they'll see that global variable and go back to sleep.
 
-So we will use \sh|tail -f| to keep the file open in the background, while trying to access it with another process (again in the background, so that we need not switch to a different vt).
+So we will use \sh|tail -f| to keep the file open in the background, and attempt to access it with another background process.
+This way, we don't need to switch to another terminal window or virtual terminal to run the second process.
 As soon as the first background process is killed with kill \%1 , the second is woken up, is able to access the file and finally terminates.
 
 To make our life more interesting, \cpp|module_close| does not have a monopoly on waking up the processes which wait to access the file.


### PR DESCRIPTION
Replaced "vt" with "virtual terminal" to improve readability, as the abbreviation appears for the first time in this section. Also rephrased to avoid nested parentheses.