### PR TITLE
Align struct file_operations with upstream v6.14

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -908,46 +908,52 @@ Each field of the structure corresponds to the address of some function defined 
 
 For example, every character driver needs to define a function that reads from the device.
 The \cpp|file_operations| structure holds the address of the module's function that performs that operation.
-Here is what the definition looks like for kernel 5.4:
+Here is what the definition looks like for kernel 6.14:
 
 \begin{code}
 struct file_operations {
     struct module *owner;
+    fop_flags_t fop_flags;
     loff_t (*llseek) (struct file *, loff_t, int);
     ssize_t (*read) (struct file *, char __user *, size_t, loff_t *);
     ssize_t (*write) (struct file *, const char __user *, size_t, loff_t *);
     ssize_t (*read_iter) (struct kiocb *, struct iov_iter *);
     ssize_t (*write_iter) (struct kiocb *, struct iov_iter *);
-    int (*iopoll)(struct kiocb *kiocb, bool spin);
-    int (*iterate) (struct file *, struct dir_context *);
+    int (*iopoll)(struct kiocb *kiocb, struct io_comp_batch *,
+        unsigned int flags);
     int (*iterate_shared) (struct file *, struct dir_context *);
     __poll_t (*poll) (struct file *, struct poll_table_struct *);
     long (*unlocked_ioctl) (struct file *, unsigned int, unsigned long);
     long (*compat_ioctl) (struct file *, unsigned int, unsigned long);
     int (*mmap) (struct file *, struct vm_area_struct *);
-    unsigned long mmap_supported_flags;
     int (*open) (struct inode *, struct file *);
     int (*flush) (struct file *, fl_owner_t id);
     int (*release) (struct inode *, struct file *);
     int (*fsync) (struct file *, loff_t, loff_t, int datasync);
     int (*fasync) (int, struct file *, int);
     int (*lock) (struct file *, int, struct file_lock *);
-    ssize_t (*sendpage) (struct file *, struct page *, int, size_t, loff_t *, int);
     unsigned long (*get_unmapped_area)(struct file *, unsigned long, unsigned long, unsigned long, unsigned long);
     int (*check_flags)(int);
     int (*flock) (struct file *, int, struct file_lock *);
     ssize_t (*splice_write)(struct pipe_inode_info *, struct file *, loff_t *, size_t, unsigned int);
     ssize_t (*splice_read)(struct file *, loff_t *, struct pipe_inode_info *, size_t, unsigned int);
-    int (*setlease)(struct file *, long, struct file_lock **, void **);
+    void (*splice_eof)(struct file *file);
+    int (*setlease)(struct file *, int, struct file_lease **, void **);
     long (*fallocate)(struct file *file, int mode, loff_t offset,
         loff_t len);
     void (*show_fdinfo)(struct seq_file *m, struct file *f);
+#ifndef CONFIG_MMU
+    unsigned (*mmap_capabilities)(struct file *);
+#endif
     ssize_t (*copy_file_range)(struct file *, loff_t, struct file *,
         loff_t, size_t, unsigned int);
     loff_t (*remap_file_range)(struct file *file_in, loff_t pos_in,
              struct file *file_out, loff_t pos_out,
              loff_t len, unsigned int remap_flags);
     int (*fadvise)(struct file *, loff_t, loff_t, int);
+    int (*uring_cmd)(struct io_uring_cmd *ioucmd, unsigned int issue_flags);
+    int (*uring_cmd_iopoll)(struct io_uring_cmd *, struct io_comp_batch *,
+          unsigned int poll_flags);
 } __randomize_layout;
 \end{code}
 


### PR DESCRIPTION
Chapter 6, "Character Device Drivers", section 6.1 still showed the v5.4 layout of 'struct file_operations'. Replace it with the version shipped in upstream Linux v6.14, keeping the example buildable and the API in step with modern kernels.

Upstream reference: https://elixir.bootlin.com/linux/v6.14/source/include/linux/fs.h#L2131