### PR TITLE
Change title to 'Synchronization' for better alignment with content

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1672,7 +1672,7 @@ There are other variations of the \cpp|wait_for_completion| function, which incl
 
 \samplec{examples/completions.c}
 
-\section{Avoiding Collisions and Deadlocks}
+\section{Synchronization}
 \label{sec:synchronization}
 If processes running on different CPUs or in different threads try to access the same memory, then it is possible that strange things can happen or your system can lock up.
 To avoid this, various types of mutual exclusion kernel functions are available.


### PR DESCRIPTION
Since the primary focus of Chapter 12 is on the techniques used to synchronize access to shared resources in a multi-CPU environment, changing the title to 'Synchronization' would better reflect the content and improve clarity. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request updates the title of Chapter 12 from 'Avoiding Collisions and Deadlocks' to 'Synchronization' to enhance clarity and better reflect the chapter's focus on synchronization techniques in multi-CPU environments.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>