### PR TITLE
Clarify ioctl third argument as untyped pointer

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1383,8 +1383,8 @@ The answer in Unix is to use a special function called \cpp|ioctl| (short for In
 Every device can have its own \cpp|ioctl| commands, which can be read ioctl's (to send information from a process to the kernel), write ioctl's (to return information to a process), both or neither.
 Notice here the roles of read and write are reversed again, so in ioctl's read is to send information to the kernel and write is to receive information from the kernel.
 
-The ioctl function is called with three parameters: the file descriptor of the appropriate device file, the ioctl number, and a parameter, which is of type long so you can use a cast to use it to pass anything.
-You will not be able to pass a structure this way, but you will be able to pass a pointer to the structure.
+The ioctl function is called with three parameters: the file descriptor of the appropriate device file that is already open, the ioctl number, and a parameter, which is an untyped pointer to memory—traditionally declared as char *argp (from the days before void * was valid in C)—allowing you to cast it to pass various types of data.
+You cannot pass a structure by value this way, but you can pass a pointer to a structure, which the kernel can then dereference and access.
 Here is an example:
 
 \samplec{examples/ioctl.c}


### PR DESCRIPTION
This pull request updates the documentation for the ioctl function, correcting the description of its third parameter. The original text incorrectly described it as being of type long. It is actually an untyped pointer to memory, traditionally declared as char *argp before void * was valid in C.

Upstream reference:https://man7.org/linux/man-pages/man2/ioctl.2.html

This change improves technical accuracy and helps developers understand how to properly pass data—particularly pointers to structures—from user space to the kernel using ioctl.

### Summary by Bito
This pull request revises the ioctl function documentation to clarify the nature of the third argument. It corrects a common misconception by specifying that the parameter is a memory pointer rather than a numeric value. The updated explanation improves clarity for developers using ioctl interfaces in kernel modules and drivers.

**Unit tests added:** False

**Estimated effort to review (1–5, lower is better):** 2