### PR TITLE
Improve example in 15.2 Work queues with error handling and cleanup

### DIFF
--- a/examples/sched.c
+++ b/examples/sched.c
@@ -16,6 +16,10 @@ static void work_handler(struct work_struct *data)
 static int __init sched_init(void)
 {
     queue = alloc_workqueue("HELLOWORLD", WQ_UNBOUND, 1);
+    if (!queue) {
+        pr_err("Failed to allocate workqueue\n");
+        return -ENOMEM;
+    }
     INIT_WORK(&work, work_handler);
     queue_work(queue, &work);
     return 0;

--- a/examples/sched.c
+++ b/examples/sched.c
@@ -27,6 +27,7 @@ static int __init sched_init(void)
 
 static void __exit sched_exit(void)
 {
+    flush_workqueue(queue);
     destroy_workqueue(queue);
 }
 


### PR DESCRIPTION
Since the example in Chapter 15.2 demonstrates the use of work queues in kernel modules, improving its reliability with proper error handling and cleanup logic helps reflect best practices in modern kernel development. This change enhances safety by preventing null pointer dereference during allocation failure and ensuring all work is completed before module unload.

### Summary by Bito
This pull request improves the example in Chapter 15.2, "Work queues", by adding error handling for alloc_workqueue() and ensuring flush_workqueue() is called before destroy_workqueue() in the module exit path. These changes align the code with kernel best practices, prevent common pitfalls like null pointer dereference, and make the example safer for readers and learners on modern kernels.

These changes improve robustness in the workqueue lifecycle and reduce the risk of memory corruption.

**Unit_tests added** : False

** Estimated effort to review (1-5, lower is better)** : 2