### PR TITLE
fix rmmod panic in bh_threaded

### DIFF
--- a/examples/bh_threaded.c
+++ b/examples/bh_threaded.c
@@ -156,7 +156,7 @@ static int __init bottomhalf_init(void)
 /* cleanup what has been setup so far */
 #ifdef NO_GPIO_REQUEST_ARRAY
 fail4:
-    free_irq(button_irqs[0], NULL);
+    free_irq(button_irqs[0], &buttons[0]);
 
 fail3:
     gpio_free(buttons[1].gpio);
@@ -168,7 +168,7 @@ fail1:
     gpio_free(leds[0].gpio);
 #else
 fail3:
-    free_irq(button_irqs[0], NULL);
+    free_irq(button_irqs[0], &buttons[0]);
 
 fail2:
     gpio_free_array(buttons, ARRAY_SIZE(leds));

--- a/examples/bh_threaded.c
+++ b/examples/bh_threaded.c
@@ -185,8 +185,8 @@ static void __exit bottomhalf_exit(void)
     pr_info("%s\n", __func__);
 
     /* free irqs */
-    free_irq(button_irqs[0], NULL);
-    free_irq(button_irqs[1], NULL);
+    free_irq(button_irqs[0], &buttons[0]);
+    free_irq(button_irqs[1], &buttons[1]);
 
 /* turn all LEDs off */
 #ifdef NO_GPIO_REQUEST_ARRAY


### PR DESCRIPTION
request_threaded_irq with device_id, so free_irq should "release" it, otherwise rmmod would panic. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a critical bug in bh_threaded.c by ensuring the free_irq function properly releases IRQs for buttons, preventing system panic during module removal and enhancing overall system stability. This enhancement is vital for maintaining overall system stability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>