### PR TITLE
examples: Refactor device model with version-based split

### DIFF
--- a/examples/devicemodel.c
+++ b/examples/devicemodel.c
@@ -23,19 +23,21 @@ static int devicemodel_probe(struct platform_device *dev)
 
     return 0;
 }
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
 static void devicemodel_remove(struct platform_device *dev)
-#else
-static int devicemodel_remove(struct platform_device *dev)
-#endif
 {
     pr_info("devicemodel example removed\n");
-
     /* Your device removal code */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
-    return 0;
-#endif
 }
+#else
+static int devicemodel_remove(struct platform_device *dev)
+{
+    pr_info("devicemodel example removed\n");
+    /* Your device removal code */
+    return 0;
+}
+#endif
 
 static int devicemodel_suspend(struct device *dev)
 {


### PR DESCRIPTION
The previous implementation of devicemodel_remove used conditional compilation to switch between void and int return types based on the kernel version. While functionally correct, the interleaved `#if/#endif` blocks made the logic harder to follow.

This refactor cleanly separates the two function definitions using a full `#if/#else` block around the entire function.

No functional behavior is changed.

Close: #313  
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request refactors the device model implementation, enhancing the readability of the devicemodel_remove function. It replaces conditional compilation with a clearer structure that separates function definitions by kernel version, without changing the functional behavior of the code.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>