### PR TITLE
Fix grammar and tense in API coexistence explanation

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1841,7 +1841,7 @@ void setup_timer(struct timer_list *timer, void (*callback)(unsigned long),
 \end{code}
 
 Since Linux v4.14, \cpp|timer_setup| is adopted and the kernel step by step converting to \cpp|timer_setup| from \cpp|setup_timer|.
-One of the reasons why API was changed is it need to coexist with the old version interface.
+One of the reasons why the API was changed is that it needed to coexist with the old version of the interface.
 Moreover, the \cpp|timer_setup| was implemented by \cpp|setup_timer| at first.
 \begin{code}
 void timer_setup(struct timer_list *timer,


### PR DESCRIPTION
The original sentence was ungrammatical and slightly unclear.
This patch improves the article usage, verb tense, and phrasing
to ensure clarity and correctness. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the clarity and grammatical correctness of the API coexistence documentation in the Linux kernel. It improves phrasing and verb tense for better understanding, making the documentation more precise and easier to read.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>