### PR TITLE
Clarify write usage in comment for /dev/chardev

### DIFF
--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -152,7 +152,7 @@ static ssize_t device_read(struct file *filp, /* see include/linux/fs.h   */
     return bytes_read;
 }
 
-/* Called when a process writes to dev file: echo "hi" > /dev/hello */
+/* Called when a process writes to dev file: echo "hi" | sudo tee /dev/chardev */
 static ssize_t device_write(struct file *filp, const char __user *buff,
                             size_t len, loff_t *off)
 {


### PR DESCRIPTION
The original comment referred to /dev/hello, but the actual device created by the module is /dev/chardev.

In addition, writing to /dev/chardev using output redirection (>) typically fails due to insufficient permissions, since redirection is handled by the shell before sudo applies. As a result, the device_write() function may never be entered.

This change updates the comment to recommend using a pipe with `sudo tee`, which correctly elevates privileges and allows the write operation to reach the driver. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request clarifies the write operation for the /dev/chardev device by correcting the previous comment that referenced /dev/hello. It now includes guidance on using a pipe with `sudo tee` to address permission issues during output redirection.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>