### PR TITLE
Fix grammer

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -677,7 +677,7 @@ EXTRAVERSION = -rc2
 
 In this case, you need to restore the value of symbol \textbf{EXTRAVERSION} to \textbf{-rc2}.
 We suggest keeping a backup copy of the makefile used to compile your kernel available in \verb|/lib/modules/5.14.0-rc2/build|.
-A simple command as following should suffice.
+A simple command as follows should suffice.
 \begin{codebash}
 cp /lib/modules/`uname -r`/build/Makefile linux-`uname -r`
 \end{codebash}


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request corrects a grammatical error in the documentation of the kernel compilation process, changing 'as following' to 'as follows'. This modification enhances the clarity and professionalism of the documentation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>