### PR TITLE
Remove unsafe try_module_get(THIS_MODULE)

### DIFF
--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -96,7 +96,6 @@ static int device_open(struct inode *inode, struct file *file)
         return -EBUSY;
 
     sprintf(msg, "I already told you %d times Hello world!\n", counter++);
-    try_module_get(THIS_MODULE);
 
     return 0;
 }
@@ -106,11 +105,6 @@ static int device_release(struct inode *inode, struct file *file)
 {
     /* We're now ready for our next caller */
     atomic_set(&already_open, CDEV_NOT_USED);
-
-    /* Decrement the usage count, or else once you opened the file, you will
-     * never get rid of the module.
-     */
-    module_put(THIS_MODULE);
 
     return 0;
 }

--- a/examples/chardev2.c
+++ b/examples/chardev2.c
@@ -40,7 +40,6 @@ static int device_open(struct inode *inode, struct file *file)
 {
     pr_info("device_open(%p)\n", file);
 
-    try_module_get(THIS_MODULE);
     return 0;
 }
 
@@ -48,7 +47,6 @@ static int device_release(struct inode *inode, struct file *file)
 {
     pr_info("device_release(%p,%p)\n", inode, file);
 
-    module_put(THIS_MODULE);
     return 0;
 }
 

--- a/examples/procfs3.c
+++ b/examples/procfs3.c
@@ -52,12 +52,10 @@ static ssize_t procfs_write(struct file *file, const char __user *buffer,
 }
 static int procfs_open(struct inode *inode, struct file *file)
 {
-    try_module_get(THIS_MODULE);
     return 0;
 }
 static int procfs_close(struct inode *inode, struct file *file)
 {
-    module_put(THIS_MODULE);
     return 0;
 }
 

--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -100,8 +100,6 @@ static int device_open(struct inode *inode, struct file *file)
         pr_alert("do unlikely thing\n");
     pr_info("fastpath 2\n");
 
-    try_module_get(THIS_MODULE);
-
     return 0;
 }
 
@@ -112,12 +110,6 @@ static int device_release(struct inode *inode, struct file *file)
 {
     /* We are now ready for our next caller. */
     atomic_set(&already_open, CDEV_NOT_USED);
-
-    /**
-     * Decrement the usage count, or else once you opened the file, you will
-     * never get rid of the module.
-     */
-    module_put(THIS_MODULE);
 
     return 0;
 }

--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -157,8 +157,6 @@ static void vinput_destroy_vdevice(struct vinput *vinput)
     clear_bit(vinput->id, vinput_ids);
     spin_unlock(&vinput_lock);
 
-    module_put(THIS_MODULE);
-
     kfree(vinput);
 }
 
@@ -181,8 +179,6 @@ static struct vinput *vinput_alloc_vdevice(void)
         pr_err("vinput: Cannot allocate vinput input device\n");
         return ERR_PTR(-ENOMEM);
     }
-
-    try_module_get(THIS_MODULE);
 
     spin_lock_init(&vinput->lock);
 
@@ -217,7 +213,6 @@ fail_input_dev:
     list_del(&vinput->list);
 fail_id:
     spin_unlock(&vinput_lock);
-    module_put(THIS_MODULE);
     kfree(vinput);
 
     return ERR_PTR(err);

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1095,16 +1095,17 @@ However, there is a counter which keeps track of how many processes are using yo
 You can see what its value is by looking at the 3rd field with the command \sh|cat /proc/modules| or \sh|lsmod|.
 If this number isn't zero, \sh|rmmod| will fail.
 Note that you do not have to check the counter within \cpp|cleanup_module| because the check will be performed for you by the system call \cpp|sys_delete_module|, defined in \src{include/linux/syscalls.h}.
-You should not use this counter directly, but there are functions defined in \src{include/linux/module.h} which let you increase, decrease and display this counter:
+You should not use this counter directly, but there are functions defined in \src{include/linux/module.h} which let you display this counter:
 
 \begin{itemize}
-  \item \cpp|try_module_get(THIS_MODULE)|: Increment the reference count of current module.
-  \item \cpp|module_put(THIS_MODULE)|: Decrement the reference count of current module.
   \item \cpp|module_refcount(THIS_MODULE)|: Return the value of reference count of current module.
 \end{itemize}
 
-It is important to keep the counter accurate; if you ever lose track of the correct usage count, you will never be able to unload the module; it is now reboot time.
-This is bound to happen to you sooner or later during a module's development.
+Note: The use of \cpp|try_module_get(THIS_MODULE)| and \cpp|module_put(THIS_MODULE)| within a module's own code is considered unsafe and should be avoided.
+The kernel automatically manages the reference count when file operations are in progress,
+so manual reference counting is unnecessary and can lead to race conditions.
+For a deeper understanding of when and how to properly use module reference counting,
+see \url{https://stackoverflow.com/questions/1741415/linux-kernel-modules-when-to-use-try-module-get-module-put}.
 
 \subsection{chardev.c}
 \label{sec:chardev_c}
@@ -1152,6 +1153,8 @@ Normal filesystems are located on a disk, rather than just in memory (which is w
 The inode contains information about the file, for example the file's permissions, together with a pointer to the disk location or locations where the file's data can be found.
 
 Because we do not get called when the file is opened or closed, there is nowhere for us to put \cpp|try_module_get| and \cpp|module_put| in this module, and if the file is opened and then the module is removed, there is no way to avoid the consequences.
+The kernel's automatic reference counting for file operations helps prevent module removal while files are in use,
+but \verb|/proc| files require careful handling due to their different lifecycle.
 
 Here is a simple example showing how to use a \verb|/proc| file.
 This is the HelloWorld for the \verb|/proc| filesystem.


### PR DESCRIPTION
This commit removes all instances of try_module_get(THIS_MODULE) and corresponding module_put(THIS_MODULE) calls from example modules. This pattern is considered unsafe because:
- The kernel automatically manages module reference counting during file operations
- Manual reference counting within a module's own code can lead to race conditions
- It is redundant and unnecessary for proper module operation

It also updates documentation to:
- Remove references to try_module_get/module_put functions
- Add note explaining why these functions should be avoided
- Keep only module_refcount() as a safe display function

Close #52 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances kernel module safety by removing unsafe functions try_module_get(THIS_MODULE) and module_put(THIS_MODULE), which can cause race conditions. It promotes the use of the safe module_refcount() function and updates the documentation accordingly.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>