### PR TITLE
Split long \footnote{} lines for improved readability

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -957,7 +957,9 @@ Some operations are not implemented by a driver.
 For example, a driver that handles a video card will not need to read from a directory structure.
 The corresponding entries in the \cpp|file_operations| structure should be set to \cpp|NULL|.
 \footnote{
-As of Linux kernel 6.12, several member fields have been added, removed, or had their prototypes changed. For example, additions include \texttt{fop\_flags}, \texttt{splice\_eof}, and \texttt{uring\_cmd}; removals include \texttt{iterate} and \texttt{sendpage}; and the prototype for \texttt{iopoll} was modified.
+As of Linux kernel 6.12, several member fields have been added, removed, or had their prototypes changed.
+For example, additions include \texttt{fop\_flags}, \texttt{splice\_eof}, and \texttt{uring\_cmd};
+removals include \texttt{iterate} and \texttt{sendpage}; and the prototype for \texttt{iopoll} was modified.
 }
 
 There is a gcc extension that makes assigning to this structure more convenient.
@@ -2009,8 +2011,13 @@ Although tasklet is easy to use, it comes with several drawbacks, and developers
 The tasklet callback runs in atomic context, inside a software interrupt, meaning that it cannot sleep or access user-space data, so not all work can be done in a tasklet handler.
 Also, the kernel only allows one instance of any given tasklet to be running at any given time; multiple different tasklet callbacks can run in parallel.
 
-In recent kernels, tasklets can be replaced by workqueues, timers, or threaded interrupts.\footnote{The goal of threaded interrupts is to push more of the work to separate threads, so that the minimum needed for acknowledging an interrupt is reduced, and therefore the time spent handling the interrupt (where it can't handle any other interrupts at the same time) is reduced.
-See \url{https://lwn.net/Articles/302043/}.}
+In recent kernels, tasklets can be replaced by workqueues, timers, or threaded interrupts.
+\footnote{
+The goal of threaded interrupts is to push more of the work to separate threads,
+so that the minimum needed for acknowledging an interrupt is reduced,
+and therefore the time spent handling the interrupt (where it can't handle any other interrupts at the same time) is reduced.
+See \url{https://lwn.net/Articles/302043/}.
+}
 While the removal of tasklets remains a longer-term goal, the current kernel contains more than a hundred uses of tasklets.
 Now developers are proceeding with the API changes and the macro \cpp|DECLARE_TASKLET_OLD| exists for compatibility.
 For further information, see \url{https://lwn.net/Articles/830964/}.


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the readability of the documentation in the `lkmpg.tex` file by breaking long footnote lines into shorter segments, improving clarity and user-friendliness for complex technical information.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on documentation improvements, making the review process relatively simple.
-->
</div>