### PR TITLE
Add inode_operations to match documentation

### DIFF
--- a/examples/procfs3.c
+++ b/examples/procfs3.c
@@ -61,6 +61,25 @@ static int procfs_close(struct inode *inode, struct file *file)
     return 0;
 }
 
+/* 
+ * In recent kernels, this would typically be handled through other mechanisms
+ * like security modules, but we keep it here for educational purposes.
+ */
+static int module_permission(struct mnt_idmap *idmap, struct inode *inode,
+                             int mask)
+{
+    pr_info("procfs: permission called with mask %d\n", mask);
+    return 0;
+}
+
+/*
+ * inode_operations structure to demonstrate the relationship between
+ * file operations and inode operations as mentioned in the documentation
+ */
+static struct inode_operations procfs_inode_operations = {
+    .permission = module_permission,
+};
+
 #ifdef HAVE_PROC_OPS
 static struct proc_ops file_ops_4_our_proc_file = {
     .proc_read = procfs_read,


### PR DESCRIPTION
The "Manage /proc file with standard filesystem" section describes using struct inode_operations with a permission function, but the referenced procfs3.c example was missing this implementation.

Close #131 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request implements the inode_operations structure in procfs3.c, adding a new permission function that logs calls and illustrates the connection between file and inode operations. This enhancement aligns with standard filesystem management practices as per the documentation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively simple.
-->
</div>