### PR TITLE
examples/sleep: clarify /proc vs procfs wording

### DIFF
--- a/examples/sleep.c
+++ b/examples/sleep.c
@@ -155,7 +155,7 @@ static int module_close(struct inode *inode, struct file *file)
  * functions.
  */
 
-/* File operations for our proc file. This is where we place pointers to all
+/* File operations for our /proc file. This is where we place pointers to all
  * the functions called when somebody tries to do something to our file. NULL
  * means we don't want to deal with something.
  */
@@ -177,7 +177,7 @@ static const struct file_operations file_ops_4_our_proc_file = {
 };
 #endif
 
-/* Initialize the module - register the proc file */
+/* Initialize the module - register the /proc file */
 static int __init sleep_init(void)
 {
     our_proc_file =


### PR DESCRIPTION
Use "/proc" when the comment refers to the actual file (/proc/sleep) and keep "proc" when it denotes the procfs mechanism or related helper APIs. This makes the documentation consistent and avoids ambiguity between a file path and the proc filesystem itself. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the clarity of comments in 'examples/sleep.c' by ensuring consistent references to the file path '/proc' and the procfs mechanism. This improves documentation quality and reduces ambiguity.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on documentation, making the review process quick and easy.
-->
</div>