### PR TITLE
Fix typo

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -47,7 +47,7 @@ all:
 
 clean:
 	$(MAKE) -C $(KDIR) CC=$(CC) M=$(PWD) clean
-	$(RM) other/cat_noblock *.plist
+	$(RM) other/cat_nonblock *.plist
 
 indent:
 	clang-format -i *.[ch]


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request corrects a minor typo in the Makefile, changing the target name from 'cat_noblock' to 'cat_nonblock' in the clean command to ensure the correct file is referenced during the clean process.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>