### PR TITLE
Fix incorrect conditional usage of .owner

### DIFF
--- a/examples/dht11.c
+++ b/examples/dht11.c
@@ -148,12 +148,10 @@ static ssize_t device_read(struct file *filp, char __user *buffer,
 }
 
 static struct file_operations fops = {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .owner = THIS_MODULE,
-#endif
     .open = device_open,
     .release = device_release,
-    .read = device_read
+    .read = device_read,
 };
 
 /* Initialize the module - Register the character device */
@@ -182,9 +180,7 @@ static int __init dht11_init(void)
             MINOR(dht11_device.dev_num));
 
     /* Prevents module unloading while operations are in use */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     dht11_device.cdev.owner = THIS_MODULE;
-#endif
 
     cdev_init(&dht11_device.cdev, &fops);
     ret = cdev_add(&dht11_device.cdev, dht11_device.dev_num, 1);

--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -140,9 +140,7 @@ static int test_ioctl_open(struct inode *inode, struct file *filp)
 }
 
 static struct file_operations fops = {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .owner = THIS_MODULE,
-#endif
     .open = test_ioctl_open,
     .release = test_ioctl_close,
     .read = test_ioctl_read,

--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -41,9 +41,7 @@ static struct class *cls;
 static DEFINE_STATIC_KEY_FALSE(fkey);
 
 static struct file_operations chardev_fops = {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .owner = THIS_MODULE,
-#endif
     .open = device_open,
     .release = device_release,
     .read = device_read,

--- a/examples/vinput.c
+++ b/examples/vinput.c
@@ -133,9 +133,7 @@ static ssize_t vinput_write(struct file *file, const char __user *buffer,
 }
 
 static const struct file_operations vinput_fops = {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .owner = THIS_MODULE,
-#endif
     .open = vinput_open,
     .release = vinput_release,
     .read = vinput_read,
@@ -337,6 +335,9 @@ ATTRIBUTE_GROUPS(vinput_class);
 
 static struct class vinput_class = {
     .name = "vinput",
+/* .owner was removed in Linux v6.4 via upstream commit 6e30a66433af ("driver core: class: remove
+ * struct module owner out of struct class")
+ */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .owner = THIS_MODULE,
 #endif


### PR DESCRIPTION
The examples code wrapped .owner = THIS_MODULE inside version checks, suggesting that it is no longer needed after v6.4. This is only true for driver types where the driver core sets .owner automatically (e.g. platform and i2c drivers).

For structures such as struct file_operations, .owner must still be set explicitly by the user. Without it, module reference counting will be broken, allowing a module to be unloaded while still in use, which can lead to kernel panics.

struct class is a special case: its .owner field was removed in upstream Linux commit 6e30a66433af ("driver core: class: remove struct module owner out of struct class"). Explicitly setting .owner for struct class is safe on older kernels but must be conditionally compiled out on newer kernels.

Remove the unnecessary version guards and unconditionally sets .owner = THIS_MODULE in the affected example code.

Closes: https://github.com/sysprog21/lkmpg/issues/348
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove version guards and always set .owner = THIS_MODULE in example drivers to fix module refcounting and avoid unload panics. This also makes the examples clearer.

- **Bug Fixes**
  - Always set .owner in struct file_operations and cdev; removed LINUX_VERSION_CODE checks to ensure correct refcounting.
  - Keep .owner in struct class unguarded; optional but correct and less confusing.

<!-- End of auto-generated description by cubic. -->

