### PR TITLE
Correct module name in rmmod example

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -591,7 +591,7 @@ myintarray[0] = -1
 myintarray[1] = -1
 got 2 arguments for myintarray.
 
-$ sudo rmmod hello-5
+$ sudo rmmod hello_5
 $ sudo dmesg -t | tail -1
 Goodbye, world 5
 


### PR DESCRIPTION
The rmmod command in the example used a hyphen (hello-5), but Linux kernel module names conventionally use underscores (hello_5) to align with C identifier naming rules.

This change corrects the module name to use an underscore, ensuring the documentation is consistent and avoiding potential confusion for readers trying to run the command.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Correct the rmmod example to use hello_5 (underscore) instead of hello-5 (hyphen), aligning with kernel module naming rules and avoiding confusion when running the command.

<!-- End of auto-generated description by cubic. -->

