### PR TITLE
Clarify init_module() deprecation for IBT-enabled kernel

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -419,7 +419,8 @@ Actually, things have changed starting with kernel 2.3.13.
 You can now use whatever name you like for the start and end functions of a module,
 and you will learn how to do this in \Cref{sec:hello_n_goodbye}.
 In fact, the new method is the preferred method.
-However, many people still use \cpp|init_module()| and \cpp|cleanup_module()| for their start and end functions.
+The old \cpp|init_module()| and \cpp|cleanup_module()| have been deprecated for x86 systems with indirect branch tracking (IBT) enabled starting from \href{https://github.com/torvalds/linux/commit/4fab2d76}{commit 4fab2d76} in kernel 6.15, causing build failures.
+However, many existing examples still use these names for their start and end functions.
 
 Typically, \cpp|init_module()| either registers a handler for something with the kernel, 
 or it replaces one of the kernel functions with its own code (usually code to do something and then call the original function).


### PR DESCRIPTION
Update the module initialization section to warn readers that using init_module() and cleanup_module() directly causes build failures on IBT (Indirect Branch Tracking) enabled systems starting from kernel 6.15[1]. This information helps newcomers identify and resolve common build errors when following older examples, since IBT has been enabled by default for x86 target since kernel 6.2[2].

Close #353 

[1] https://github.com/torvalds/linux/commit/4fab2d76
[2] https://github.com/torvalds/linux/commit/4fd5f70

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the module initialization docs to warn that using init_module() and cleanup_module() directly causes build failures on IBT-enabled kernels (6.15+), with IBT enabled by default on x86 since 6.2. Points readers to the preferred module_init/module_exit approach so they avoid outdated examples and build errors.

<sup>Written for commit b8063799199b684c2962e684bf45ed70bd94684c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

