### PR TITLE
Fix code block misalignment

### DIFF
--- a/lib/codeblock.tex
+++ b/lib/codeblock.tex
@@ -28,8 +28,8 @@
 \newminted[codebash]{bash}{frame=single,
   framesep=2mm,
   baselinestretch=1.2,
+  numbersep=8pt,
   breaklines,
-  breakafter=d,
   linenos
 }
 


### PR DESCRIPTION
Close #355 .

Removing `breakafter=d` fixes the HTML layout issues. The code blocks now render properly without it. I don't think this parameter is necessary for our use case.

<details>
<summary> changes </summary>
Before:
<img width="1335" height="159" alt="image" src="https://github.com/user-attachments/assets/cd17cbb0-21ec-4f32-a5f6-2a446f7728ca" />
<img width="1408" height="334" alt="image" src="https://github.com/user-attachments/assets/db827583-e88b-428a-92b3-92ecf8518b2a" />


After:
<img width="1335" height="159" alt="image" src="https://github.com/user-attachments/assets/d8cfcf63-05fc-451b-afb4-170fc241a80f" />

<img width="1419" height="332" alt="image" src="https://github.com/user-attachments/assets/37450369-c661-438f-bece-7b584192bc62" />
</detials>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned HTML code blocks by removing breakafter=d and adding numbersep=8pt in the codebash minted config in lib/codeblock.tex. This prevents unwanted line breaks and ensures proper spacing between line numbers and code.

<sup>Written for commit 3af580959315a2ffc80b46abe3b46b1c2e22ce4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

