### PR TITLE
gitignore: Add *.ttf/png and cleanup whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,21 +20,23 @@ lkmpg.pdf
 *.toc
 *.bbl
 *.blg
-*.fdb_latexmk 
+*.fdb_latexmk
 *.fls
 lkmpg.synctex.gz
 
 # make4ht
 *.html
-*.svg 
+*.svg
 *.tmp
-*.css 
-*.4ct 
-*.4tc 
-*.dvi 
-*.lg 
+*.css
+*.4ct
+*.4tc
+*.dvi
+*.lg
 *.idv
 *.xref
+*.ttf
+*.png
 
 # format checks
 expected-format


### PR DESCRIPTION
- Ignore ttf/png assets generated by `make html`.
- Remove trailing whitespaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent committing HTML build artifacts by adding *.ttf and *.png to .gitignore. Also remove trailing whitespace for consistency.

<sup>Written for commit 000e33691aa4aeb5d3b868b22f2b11d0875d6143. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

