### PR TITLE
fix: Retrieve user value in IOCTL_VALSET_NUM case

### DIFF
--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -75,7 +75,9 @@ static long test_ioctl_ioctl(struct file *filp, unsigned int cmd,
         break;
 
     case IOCTL_VALSET_NUM:
-        ioctl_num = arg;
+        int user_val;
+        if (get_user(user_val, (int __user *)arg))
+            return -EFAULT;
         break;
 
     default:


### PR DESCRIPTION
The test program is:

``` c
    arg.val = 0xAA;
    ioctl(fd, IOCTL_VALSET_NUM, &arg);

    arg.val = 0;
    ioctl(fd, IOCTL_VALGET_NUM, &arg);
    printf("Read val: 0x%x\n", arg.val);
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix IOCTL_VALSET_NUM to correctly read the user-provided integer from user space using get_user. Prevents misinterpreting a user pointer as a value and returns -EFAULT on copy failure.

<sup>Written for commit 77aa5e52aa39e26756b2da3354b08d5b52a5e6ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

