### PR TITLE
Fix retrieve user value in IOCTL_VALSET_NUM case

### DIFF
--- a/examples/ioctl.c
+++ b/examples/ioctl.c
@@ -20,7 +20,7 @@ struct ioctl_arg {
 #define IOCTL_VALSET _IOW(IOC_MAGIC, 0, struct ioctl_arg)
 #define IOCTL_VALGET _IOR(IOC_MAGIC, 1, struct ioctl_arg)
 #define IOCTL_VALGET_NUM _IOR(IOC_MAGIC, 2, int)
-#define IOCTL_VALSET_NUM _IOW(IOC_MAGIC, 3, int)
+#define IOCTL_VALSET_NUM _IO(IOC_MAGIC, 3)
 
 #define IOCTL_VAL_MAXNR 3
 #define DRIVER_NAME "ioctltest"


### PR DESCRIPTION
The test program is:

``` c
    arg.val = 0xAA;
    ioctl(fd, IOCTL_VALSET_NUM, &arg);

    arg.val = 0;
    ioctl(fd, IOCTL_VALGET_NUM, &arg);
    printf("Read val: 0x%x\n", arg.val);
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch IOCTL_VALSET_NUM to _IO so the integer is passed via the ioctl arg, matching the driver handler and example calls. This fixes the set/get number flow and keeps the convention consistent across the codebase.

<sup>Written for commit 113cd574bb8b47df4fbc57e5a15eda3873068f6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

