### PR TITLE
Clarify __init wording for loadable modules

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -500,7 +500,8 @@ the last time you ran \sh|make menuconfig| or something similar.
 
 \subsection{The \_\_init and \_\_exit Macros}
 \label{sec:init_n_exit}
-The \cpp|__init| macro causes the init function to be discarded and its memory freed once the init function finishes for built-in drivers, but not loadable modules.
+The \cpp|__init| macro causes the init function to be discarded and its memory freed once the init function finishes for built-in drivers.
+For loadable modules, \cpp|__init| still places the function into an init-only section, \cpp|do_free_init| may still be observable during module loading even without \cpp|__init|.
 If you think about when the init function is invoked, this makes perfect sense.
 
 There is also an \cpp|__initdata| which works similarly to \cpp|__init| but for init variables rather than functions.


### PR DESCRIPTION
Replace the phrase "but not loadable modules" with more explicit description in section 4.3.

The current wording can be misread as implying that __init has no observable effect for loadable modules.

closes #360 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the documentation for the __init macro to avoid implying it has no effect for loadable modules. The text now explains that __init still places functions in an init-only section for modules and that do_free_init may be observable during module loading.

<sup>Written for commit e25ae0b93c673703f3b8d5786835a86fe5b25bd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

