### PR TITLE
Add error handling for class_create()

### DIFF
--- a/examples/chardev.c
+++ b/examples/chardev.c
@@ -67,6 +67,11 @@ static int __init chardev_init(void)
 #else
     cls = class_create(THIS_MODULE, DEVICE_NAME);
 #endif
+    if (IS_ERR(cls)) {
+        pr_err("Failed to create class for device\n");
+        unregister_chrdev(major, DEVICE_NAME);
+        return PTR_ERR(cls);
+    }
     device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);
 
     pr_info("Device created on /dev/%s\n", DEVICE_NAME);

--- a/examples/chardev2.c
+++ b/examples/chardev2.c
@@ -208,6 +208,11 @@ static int __init chardev2_init(void)
 #else
     cls = class_create(THIS_MODULE, DEVICE_FILE_NAME);
 #endif
+    if (IS_ERR(cls)) {
+        pr_err("Failed to create class for device\n");
+        unregister_chrdev(MAJOR_NUM, DEVICE_NAME);
+        return PTR_ERR(cls);
+    }
     device_create(cls, NULL, MKDEV(MAJOR_NUM, 0), NULL, DEVICE_FILE_NAME);
 
     pr_info("Device created on /dev/%s\n", DEVICE_FILE_NAME);

--- a/examples/static_key.c
+++ b/examples/static_key.c
@@ -63,7 +63,11 @@ static int __init chardev_init(void)
 #else
     cls = class_create(THIS_MODULE, DEVICE_NAME);
 #endif
-
+    if (IS_ERR(cls)) {
+        pr_err("Failed to create class for device\n");
+        unregister_chrdev(major, DEVICE_NAME);
+        return PTR_ERR(cls);
+    }
     device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);
 
     pr_info("Device created on /dev/%s\n", DEVICE_NAME);


### PR DESCRIPTION
Check the return value of class_create() in chardev.c and chardev2.c, unregistering the char device and returning the error code if class creation fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle class_create() failures in the example char drivers to avoid leaks and return clear errors. On failure, we now unregister the char device and return PTR_ERR.

- **Bug Fixes**
  - Check IS_ERR(cls) after class_create in chardev.c, chardev2.c, and static_key.c.
  - On failure: log with pr_err, unregister_chrdev, and return PTR_ERR.

<sup>Written for commit fdf50cc4419f469da355b61fc90090bfe20e33ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

