### PR TITLE
Add NULL-check platform_data before dereferencing in devicemodel_probe

### DIFF
--- a/examples/devicemodel.c
+++ b/examples/devicemodel.c
@@ -16,6 +16,11 @@ static int devicemodel_probe(struct platform_device *dev)
     struct devicemodel_data *pd =
         (struct devicemodel_data *)(dev->dev.platform_data);
 
+    if (!pd) {
+        pr_err("No platform data provided\n");
+        return -EINVAL;
+    }
+
     pr_info("devicemodel probe\n");
     pr_info("devicemodel greeting: %s; %d\n", pd->greeting, pd->number);
 


### PR DESCRIPTION
dev->dev.platform_data is optional and not guaranteed to be set by the platform device registrar. Add a NULL guard and return -EINVAL to fail the probe cleanly instead of crashing the kernel with a NULL dereference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a NULL check for platform_data in devicemodel_probe to prevent a NULL dereference and kernel crash. If platform data is missing, log an error and return -EINVAL to fail the probe cleanly.

<sup>Written for commit 1d3a336b8324794779851cc81cb082885169ac7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

