### PR TITLE
Add chapter structure and sidebar TOC

### DIFF
--- a/html.cfg
+++ b/html.cfg
@@ -3,7 +3,6 @@
 \Configure{tableofcontents*}{chapter,section,subsection}
 
 \Css{html {
-    width: 100vw;
     overflow-x: hidden;
 }}
 
@@ -13,31 +12,194 @@
 }}
 
 \Css{body {
-    max-width: 55rem;
     box-sizing: border-box;
-    padding: 1rem;
-    margin: 0 auto;
+    width: auto;
+    max-width: none;
+    min-height: 100vh;
+    padding: 1rem 2rem 2rem 24rem;
+    margin: 0;
     overflow-x: hidden;
     background-color: \#F4ECD8;
     color: \#5B464B;
     line-height: 1.5;
 }}
 
+\Css{body > :not(.tableofcontents) {
+    box-sizing: border-box;
+    width: auto;
+    max-width: 70rem;
+    margin-left: 0;
+    margin-right: 0;
+}}
+
+\Css{.tableofcontents {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    bottom: 1rem;
+    z-index: 10;
+    width: 19rem;
+    max-width: none;
+    margin: 0;
+    overflow-y: auto;
+    padding: 1.5rem 1.25rem 2rem;
+    border-right: 1px solid \#d6c6aa;
+    background: linear-gradient(180deg, \#efe4ca 0\%, \#eadcbf 100\%);
+    box-shadow: inset -1px 0 0 rgba(91, 70, 75, 0.08);
+}}
+
+\Css{.tableofcontents::before {
+    content: "Contents";
+    display: block;
+    margin-bottom: 1rem;
+    font-family: Manrope;
+    font-size: 0.9rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: \#5B464B;
+}}
+
+\Css{.chapterToc, .sectionToc, .subsectionToc {
+    display: block;
+    font-family: Manrope;
+}}
+
+\Css{.chapterToc {
+    margin-top: 1.1rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgba(91, 70, 75, 0.14);
+    font-size: 1rem;
+    font-weight: 800;
+    line-height: 1.45;
+}}
+
+\Css{.chapterToc:first-child {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: 0;
+}}
+
+\Css{.chapterToc a {
+    color: \#5B464B;
+    text-decoration: none;
+    line-height: inherit;
+    font-weight: inherit;
+}}
+
+\Css{.sectionToc {
+    margin-top: 0.35rem;
+    margin-left: 0;
+    font-size: 0.95rem;
+    line-height: 1.45;
+}}
+
+\Css{.sectionToc a {
+    color: \#7a5a4f;
+    text-decoration: none;
+}}
+
+\Css{.subsectionToc {
+    margin-top: 0.18rem;
+    margin-left: 0.9rem;
+    font-size: 0.82rem;
+    line-height: 1.35;
+}}
+
+\Css{.subsectionToc a {
+    color: \#6b4f54;
+    text-decoration: none;
+}}
+
+\Css{.tableofcontents a {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}}
+
+\Css{.tableofcontents a:hover {
+    color: \#0060DF;
+    text-decoration: underline;
+}}
+
+\Css{.likechapterHead\#contents {
+    display: none;
+}}
+
 \Css{a {
-color: \#0060DF;
+    color: \#0060DF;
+}}
+
+\Css{a:focus-visible {
+    outline: 3px solid \#0060DF;
+    outline-offset: 2px;
+    border-radius: 2px;
 }}
 
 \Css{p, a {
-font-size: 1.2rem;
-font-family: Manrope;
+    font-size: 1.2rem;
+    font-family: Manrope;
 }}
 
 \Css{p + pre {
-font-size: 1.1em;
+    font-size: 1.1em;
 }}
 
 \Css{div.author {
     white-space: normal;
+}}
+
+\Css{.maketitle {
+    min-height: auto;
+    padding: 0;
+    margin-top: 3rem;
+    margin-bottom: 1rem;
+}}
+
+\Css{.maketitle + p {
+    width: min(24rem, 100\%);
+    max-width: 24rem;
+    float: none;
+    margin: 1.5rem auto 2rem;
+}}
+
+\Css{.maketitle + p img {
+    display: block;
+    width: 100\%;
+    max-width: 100\%;
+    max-height: 78vh;
+    margin: 0;
+}}
+
+\Css{.maketitle .titleHead {
+    margin: 0;
+    text-align: center;
+    font-family: Manrope;
+    max-width: none;
+    font-size: 4.6rem;
+    line-height: 0.92;
+    letter-spacing: -0.05em;
+}}
+
+\Css{.maketitle .author {
+    text-align: center;
+    max-width: none;
+    margin-top: 1.5rem;
+    color: \#735c61;
+}}
+
+\Css{.maketitle .author span {
+    font-size: 1.55rem;
+    line-height: 1.5;
+}}
+
+\Css{.maketitle .date {
+    text-align: center;
+    margin-top: 1rem;
+    max-width: none;
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: \#8c7277;
 }}
 
 \Css{img.math {
@@ -45,7 +207,7 @@ font-size: 1.1em;
     vertical-align: top;
 }}
 
-\Css{pre.fancyvrb, {
+\Css{pre.fancyvrb {
     white-space: pre;
 }}
 
@@ -66,26 +228,111 @@ font-size: 1.1em;
     user-select: none;
 }}
 
-\Css{.flushright:first-child {
-    position:absolute;
-    top: 10px;
-    right: 50px;
+\Css{.page-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin: 0 0 1.5rem;
 }}
 
-\Css{.right {
-    text-align: right;
+\Css{@media (max-width: 1100px) {
+    body {
+        padding: 0 1rem 2rem;
+    }
+    body > :not(.tableofcontents) {
+        width: auto;
+        max-width: none;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    .tableofcontents {
+        position: static;
+        width: auto;
+        max-width: 55rem;
+        margin: 1rem auto 1.5rem;
+        border-right: 0;
+        border: 1px solid \#d6c6aa;
+        border-radius: 14px;
+        box-shadow: none;
+    }
+    .maketitle {
+        min-height: auto;
+        margin-top: 0;
+    }
+    .page-actions {
+        justify-content: center;
+    }
+    .maketitle + p {
+        width: min(22rem, 100\%);
+        max-width: 22rem;
+        margin-top: 1rem;
+    }
 }}
 
-\AtBeginDocument{%
+\Css{@media (max-width: 900px) {
+    .maketitle + p {
+        width: 100\%;
+        max-width: 24rem;
+        margin: 1rem auto 0;
+    }
+    .maketitle .titleHead,
+    .maketitle .author,
+    .maketitle .date {
+        max-width: none;
+        text-align: center;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    .maketitle + p img {
+        max-height: none;
+        margin: 0 auto;
+    }
+}}
+
+\Css{@media print {
+    body {
+        display: block;
+        padding: 0;
+    }
+    .tableofcontents {
+        position: static;
+        width: auto;
+        max-height: none;
+        border-right: 0;
+        box-shadow: none;
+        background: none;
+        page-break-after: always;
+    }
+    .page-actions {
+        display: none;
+    }
+    .maketitle {
+        min-height: auto;
+        margin: 0;
+    }
+    .maketitle .titleHead,
+    .maketitle .author,
+    .maketitle .date {
+        max-width: none;
+    }
+    .maketitle + p {
+        float: none;
+        width: auto;
+        max-width: 20rem;
+        margin: 1rem 0 0;
+    }
+}}
+
 \Configure{@HEAD}{\HCode{
     <script async defer src="https://buttons.github.io/buttons.js"></script>
-    <div class="right">
+\Hnewline}}
+
+\Configure{@BODY}{\ifvmode \IgnorePar\fi \EndP\HCode{
+    <div class="page-actions">
         <a class="github-button" href="https://github.com/sysprog21/lkmpg" data-size="large" aria-label="View on GitHub">View on GitHub</a>
         <a class="github-button" href="https://github.com/sysprog21/lkmpg/releases/download/latest/lkmpg.pdf" data-icon="octicon-download" data-size="large" aria-label="Download PDF document">Download PDF document</a>
-        <br><br>
     </div>
     \Hnewline}}
-}
 
 \begin{document}
 \EndPreamble

--- a/lib/codeblock.tex
+++ b/lib/codeblock.tex
@@ -1,3 +1,76 @@
+\ifdefined\HCode
+\RecustomVerbatimEnvironment{Verbatim}{Verbatim}{
+  frame=single,
+  framesep=2mm,
+  baselinestretch=1,
+  fontsize=\footnotesize,
+  breaklines=true,
+  numbers=left
+}
+
+\DefineVerbatimEnvironment{code}{Verbatim}{
+  frame=single,
+  framesep=2mm,
+  baselinestretch=1,
+  fontsize=\footnotesize,
+  breaklines=true,
+  numbers=left
+}
+
+\DefineVerbatimEnvironment{codebash}{Verbatim}{
+  frame=single,
+  framesep=2mm,
+  baselinestretch=1.2,
+  fontsize=\footnotesize,
+  breaklines=true,
+  numbers=left
+}
+
+\NewDocumentCommand{\samplec}{oom}{%
+  \IfNoValueTF{#1}%
+  {%
+    \VerbatimInput[
+      frame=single,
+      framesep=2mm,
+      baselinestretch=1,
+      fontsize=\footnotesize,
+      breaklines=true,
+      numbers=left
+    ]{#3}%
+  }%
+  {%
+    \IfNoValueTF{#2}%
+    {%
+      \VerbatimInput[
+        frame=single,
+        framesep=2mm,
+        baselinestretch=1,
+        fontsize=\footnotesize,
+        breaklines=true,
+        firstline=#1,
+        numbers=left
+      ]{#3}%
+    }%
+    {%
+      \VerbatimInput[
+        frame=single,
+        framesep=2mm,
+        baselinestretch=1,
+        fontsize=\footnotesize,
+        breaklines=true,
+        firstline=#1,
+        lastline=#2,
+        numbers=left
+      ]{#3}%
+    }%
+  }%
+}
+
+\NewDocumentCommand{\sh}{v}{\texttt{#1}}
+\NewDocumentCommand{\cpp}{v}{\texttt{#1}}
+
+\else
+
 \newminted[code]{c}{frame=single,
   framesep=2mm,
   baselinestretch=1,
@@ -35,3 +108,5 @@
 
 \newmintinline[sh]{bash}{}
 \newmintinline[cpp]{c}{}
+
+\fi

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1,5 +1,7 @@
 \documentclass[10pt, oneside]{book}
+\ifdefined\HCode\else
 \usepackage[Bjornstrup]{fncychap}
+\fi
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage{graphicx}
@@ -35,11 +37,13 @@
   urlcolor = {blue!80!black}
 }
 
+\makeatletter
+\@removefromreset{section}{chapter}
+\makeatother
+\renewcommand{\thesection}{\arabic{section}}
+
 \input{lib/codeblock}
 \input{lib/kernelsrc}
-
-% FIXME: classify with chapters instead of sections
-\renewcommand{\thesection}{\arabic{section}}
 
 \author{Peter Jay Salzman, Michael Burian, Ori Pomerantz, Bob Mottram, Jim Huang}
 \date{\today}
@@ -49,7 +53,7 @@
 \maketitle
 \ifdefined\HCode
 \includegraphics{assets/cover-with-names.png}
-% turn off TOC
+\tableofcontents
 \else
 \pagestyle{empty}
 \begin{tikzpicture}[remember picture, overlay]
@@ -60,6 +64,12 @@
 \end{tikzpicture}
 \tableofcontents
 \fi
+
+\chapter{Getting Started}
+This chapter introduces the guide, outlines the basic development environment,
+and builds up from the first loadable module. The emphasis is on getting a
+working workflow in place before moving on to the broader kernel interfaces
+used by more capable modules.
 
 \section{Introduction}
 \label{sec:introduction}
@@ -204,7 +214,7 @@ It is reassuring to note that overcoming the initial obstacle on the first attem
         more detailed steps for \href{https://wiki.debian.org/SecureBoot}{SecureBoot} can be explored and followed.
 \end{enumerate}
 
-\section{Headers}
+\section{Kernel Headers}
 \label{sec:headers}
 Before building anything, it is necessary to install the header files for the kernel.
 
@@ -739,6 +749,12 @@ $ make
 
 If you do not desire to actually compile the kernel, you can interrupt the build process (CTRL-C) just after the SPLIT line, because at that time, the files you need are ready.
 Now you can turn back to the directory of your module and compile it: It will be built exactly according to your current kernel settings, and it will load into it without any errors.
+
+\chapter{Core Kernel Interfaces}
+With the toolchain and first examples out of the way, the focus shifts to the
+interfaces that let modules cooperate with the rest of the kernel. The
+following sections introduce execution basics and then move through the common
+entry points used to expose functionality to user space.
 
 \section{Preliminaries}
 \subsection{How modules begin and end}
@@ -1454,6 +1470,13 @@ The solution is using atomic Compare-And-Swap (CAS), which we mentioned at \Cref
 
 \samplec{examples/other/userspace_ioctl.c}
 
+\chapter{Execution Context and Control Flow}
+Kernel code runs under a variety of constraints depending on where it executes.
+Some paths may sleep, some must return quickly, and some need careful
+synchronization to stay correct on modern SMP systems. This chapter collects
+the mechanisms that shape control flow, blocking behavior, deferred work, and
+debugging.
+
 \section{System Calls}
 \label{sec:syscall}
 So far, the only thing we've done was to use well defined kernel mechanisms to register \verb|/proc| files and device handlers.
@@ -1919,6 +1942,12 @@ Logging over a netconsole might also be worth a try.
 While you have seen lots of stuff that can be used to aid debugging here, there are some things to be aware of. Debugging is almost always intrusive.
 Adding debug code can change the situation enough to make the bug seem to disappear.
 Thus, you should keep debug code to a minimum and make sure it does not show up in production code.
+
+\chapter{Hardware Integration and Advanced Topics}
+The remaining material brings together hardware-facing examples and the kernel
+subsystems that support them. It also closes the guide with a compact set of
+optimization notes, common mistakes, and references for readers who want to
+keep exploring beyond the examples in this book.
 
 \section{GPIO}
 \label{sec:gpio}


### PR DESCRIPTION
This organizes into four chapters (Getting Started, Core Kernel Interfaces, Execution Context and Control Flow, Hardware Integration and Advanced Topics) while preserving flat section numbering via \@removefromreset to avoid breaking existing references.

Enable the table of contents in HTML output and style it as a fixed sidebar with responsive collapse at 1100px. Override tex4ht default cascade for TOC indentation and chapterToc link properties. Add focus-visible outlines, print stylesheet, and WCAG AA contrast.

Provide fancyvrb-based fallbacks for minted environments in HTML mode (lib/codeblock.tex) so code blocks render with line numbers and proper framing under tex4ht. Disable fncychap in HTML mode to avoid its line-break errors in tex4ht processing.

Close #26

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a four‑chapter structure and a responsive HTML sidebar table of contents to improve navigation without breaking existing section anchors. Also fixes HTML build issues and ensures code blocks render reliably. Closes #26.

- **New Features**
  - Organized content into four chapters; kept flat section numbering using \@removefromreset to preserve existing links.
  - Enabled `\tableofcontents` in HTML with a fixed sidebar that collapses below 1100px; custom TOC indentation/link styles, focus-visible outlines, and WCAG AA contrast.
  - Added a print stylesheet and responsive layout updates; moved GitHub action buttons into a `.page-actions` toolbar.
  - Provided `fancyvrb` fallbacks for `minted` environments in `tex4ht` HTML mode so code blocks have line numbers and frames.

- **Bug Fixes**
  - Disabled `fncychap` in HTML mode to avoid `tex4ht` line-break errors during processing.

<sup>Written for commit 1583d277d06f261052c31a9307717d1d8746a00d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

