### PR TITLE
Upgrade clang-format to version 20

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -7,9 +7,9 @@ if [ ${#SOURCES[@]} -eq 0 ]; then
     exit 0
 fi
 
-CLANG_FORMAT=$(command -v clang-format)
+CLANG_FORMAT=$(command -v clang-format-20 || command -v clang-format || true)
 if [ -z "${CLANG_FORMAT}" ]; then
-    echo "[!] clang-format not installed. Unable to check source file format policy." >&2
+    echo "[!] clang-format not installed. Install clang-format-20 or clang-format." >&2
     exit 1
 fi
 

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -46,12 +46,17 @@ jobs:
             command: .ci/check-newline.sh
             artifact_name: newline-logs
           - name: Check source formatting
-            packages: clang-format
+            packages: clang-format-20
             command: .ci/check-format.sh
             artifact_name: format-logs
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Add LLVM repository
+        if: contains(matrix.packages, 'clang-format-20')
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main'
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ html: lkmpg.tex html.cfg assets/Manrope_variable.ttf
 	rm -rf _minted-$(PROJ) _minted-lkmpg-for-ht
 
 indent:
-	(cd examples; find . -name '*.[ch]' | xargs clang-format -i)
+	$(MAKE) -C examples indent
 
 clean:
 	rm -f *.dvi *.aux *.log *.ps *.pdf *.out lkmpg.bbl lkmpg.blg lkmpg.lof lkmpg.toc lkmpg.fdb_latexmk lkmpg.fls

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -43,6 +43,7 @@ obj-m += vnetloop.o
 
 KDIR ?= /lib/modules/$(shell uname -r)/build
 PWD := $(CURDIR)
+CLANG_FORMAT ?= $(shell command -v clang-format-20 2>/dev/null || command -v clang-format 2>/dev/null)
 
 ifeq ($(CONFIG_STATUS_CHECK_GCC),y)
 CC=$(STATUS_CHECK_GCC)
@@ -57,5 +58,9 @@ clean:
 	$(RM) other/cat_nonblock *.plist
 
 indent:
-	clang-format -i *.[ch]
-	clang-format -i other/*.[ch]
+	@if [ -z "$(CLANG_FORMAT)" ]; then \
+		echo "No clang-format found. Install clang-format-20 or clang-format." >&2; \
+		exit 1; \
+	fi
+	"$(CLANG_FORMAT)" -i *.[ch]
+	"$(CLANG_FORMAT)" -i other/*.[ch]


### PR DESCRIPTION
Ubuntu 24.04 does not ship clang-format-20, so CI now adds the LLVM apt repository before installing the package. Scripts and Makefiles prefer clang-format-20 but fall back to the unversioned binary for contributor convenience.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade formatting tooling to `clang-format-20` and ensure CI installs it on Ubuntu 24.04. Scripts and Makefiles prefer `clang-format-20` and fall back to `clang-format` for local convenience.

- **Dependencies**
  - CI installs `clang-format-20` via the LLVM apt repository on Ubuntu 24.04.
  - GitHub Actions workflow updated to request `clang-format-20`.

- **Refactors**
  - `.ci/check-format.sh` now tries `clang-format-20` first, then `clang-format`, with a clearer error message.
  - `examples/Makefile` detects the available formatter and uses it for the `indent` target; errors if none found.
  - Top-level `Makefile` delegates `indent` to `examples`.

<sup>Written for commit c776151071e5e08e489cb545afba7c1f229609a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

