### PR TITLE
Fix HTML code block indentation in make4ht output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,14 @@ $(PROJ).pdf: lkmpg.tex
 	rm -rf _minted-$(PROJ)
 	latexmk -shell-escape lkmpg.tex -pdf
 
-html: lkmpg.tex html.cfg assets/Manrope_variable.ttf
+html: lkmpg.tex html.cfg assets/Manrope_variable.ttf $(wildcard examples/*.[ch] examples/other/*.[ch])
 	sed $ 's/\t/    /g' lkmpg.tex > lkmpg-for-ht.tex
 	make4ht --shell-escape --utf8 --format html5 --config html.cfg --output-dir html  lkmpg-for-ht.tex "fn-in"
+	python3 -c "\
+	import re, sys; \
+	f=open('html/lkmpg-for-ht.html','r'); s=f.read(); f.close(); \
+	s=re.sub(r\"(<span class='ecrm-0500'>\d+)([ ]+)</span>\",lambda m:m.group(1)+'</span>'+' '*int(len(m.group(2))*4/7),s); \
+	f=open('html/lkmpg-for-ht.html','w'); f.write(s); f.close()"
 	ln -sf lkmpg-for-ht.html html/index.html
 	cp assets/Manrope_variable.ttf html/Manrope_variable.ttf
 	rm -f  lkmpg-for-ht.tex lkmpg-for-ht.xref lkmpg-for-ht.tmp lkmpg-for-ht.html lkmpg-for-ht.css lkmpg-for-ht.4ct lkmpg-for-ht.4tc lkmpg-for-ht.dvi lkmpg-for-ht.lg lkmpg-for-ht.idv lkmpg*.svg lkmpg-for-ht.log lkmpg-for-ht.aux


### PR DESCRIPTION
tex4ht places indentation whitespace inside the line-number <span> (class ecrm-0500), but CSS gives that span display:inline-block with a fixed width, so the spaces never affect layout -- all code lines start at the same horizontal position regardless of indent depth.

Post-process the HTML after make4ht to move trailing spaces from inside the line-number span to outside it, and normalize the space count by a factor of 4/7 to correct the TeX-to-HTML font metric mismatch (tex4ht inflates space counts by ~1.75x due to footnotesize character width calculations).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix HTML code block indentation in `make4ht` output so nested code renders correctly by moving indent spaces out of the line-number span and normalizing their width.

- **Bug Fixes**
  - Post-process `html/lkmpg-for-ht.html` to move trailing spaces from inside `<span class='ecrm-0500'>` to after it, restoring visible indentation.
  - Normalize indent width by a 4/7 factor to correct `tex4ht` space inflation (~1.75x).
  - Add `examples/*.[ch]` and `examples/other/*.[ch]` as `html` target deps to rebuild when examples change.

<sup>Written for commit 0500e79f080a64895f4c82fbb8892faf4f80453a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

