### PR TITLE
Fix prebuilt tarball hardcoding CI build path

### DIFF
--- a/devtools/pack-prebuilt.sh
+++ b/devtools/pack-prebuilt.sh
@@ -63,8 +63,12 @@ cp "$KERNEL_BUILD/.config" "$STAGE_BUILD/"
 cp "$KERNEL_BUILD/Module.symvers" "$STAGE_BUILD/"
 [ -f "$KERNEL_BUILD/modules.order" ] && cp "$KERNEL_BUILD/modules.order" "$STAGE_BUILD/"
 
-# Top-level Makefile (kbuild entry point when using O=)
+# Top-level Makefile (kbuild entry point when using O=).
+# kbuild generates this with an absolute include path; rewrite it to use a
+# relative "source" symlink so the prebuilt tarball is machine-independent.
 cp "$KERNEL_BUILD/Makefile" "$STAGE_BUILD/"
+sed -i "s|^include .*/linux-${KERNEL_VERSION}/Makefile|include source/Makefile|" \
+    "$STAGE_BUILD/Makefile"
 
 # Config stamp (for setup.sh staleness detection)
 [ -f "$KERNEL_BUILD/.config-stamp" ] && cp "$KERNEL_BUILD/.config-stamp" "$STAGE_BUILD/"
@@ -92,6 +96,12 @@ rsync -a \
     --exclude='*.o' --exclude='*.o.d' --exclude='.*.cmd' \
     --exclude='*.a' --exclude='.tmp_*' \
     "$KERNEL_BUILD/scripts/" "$STAGE_BUILD/scripts/"
+
+# objtool (host tool required for out-of-tree module builds with CONFIG_OBJTOOL)
+if [ -f "$KERNEL_BUILD/tools/objtool/objtool" ]; then
+    mkdir -p "$STAGE_BUILD/tools/objtool"
+    cp "$KERNEL_BUILD/tools/objtool/objtool" "$STAGE_BUILD/tools/objtool/"
+fi
 
 # bzImage for QEMU boot
 mkdir -p "$STAGE_BUILD/arch/x86/boot"


### PR DESCRIPTION
Rewrite the generated Makefile include directive to use a relative "source/Makefile" path instead of the absolute CI machine path, so out-of-tree module builds work on any machine.

Also include objtool in the tarball when CONFIG_OBJTOOL=y.

Fixes #375

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the prebuilt kernel tarball portable by replacing the absolute Makefile include path with a relative source/Makefile. Also include objtool when CONFIG_OBJTOOL=y to support out-of-tree module builds (fixes #375).

<sup>Written for commit e0dfb3ef66db104d0a256d098df4d300c57fbccd. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/lkmpg/pull/376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

