### PR TITLE
Fix QEMU hanging when boot.sh --test output is piped

### DIFF
--- a/devtools/boot.sh
+++ b/devtools/boot.sh
@@ -86,4 +86,13 @@ fi
 # Append any extra user-provided QEMU args
 QEMU_ARGS+=("${EXTRA_QEMU_ARGS[@]+"${EXTRA_QEMU_ARGS[@]}"}")
 
-exec "$QEMU_BIN" "${QEMU_ARGS[@]}"
+# In test mode the guest never reads stdin.  Redirect from /dev/null so
+# QEMU's -nographic serial setup never calls tcsetattr() on a real
+# terminal, which would receive SIGTTOU if the caller piped stdout or
+# wrapped boot.sh with timeout(1) (whose child runs in its own process
+# group, not the terminal's foreground group).
+if [ -n "$TEST_CMD" ]; then
+    exec "$QEMU_BIN" "${QEMU_ARGS[@]}" < /dev/null
+else
+    exec "$QEMU_BIN" "${QEMU_ARGS[@]}"
+fi


### PR DESCRIPTION
 When I ran `devtools/test-modules.sh` from my terminal, it printed "Booting QEMU for testing" and then produced no further output.  In `ps aux`,  QEMU was stuck in state `Tl` (stopped).                                                                 
                                                                                                          
Root cause: `-nographic` makes QEMU call `tcsetattr()` to put the terminal in raw mode for serial input.  That's fine when QEMU runs in the foreground, but `test-modules.sh` pipes stdout through `tee`, and `timeout(1)` moves the child into its own process group (so it can kill the whole group on timeout).  Since that group isn't the  terminal's foreground group, `tcsetattr()` receives `SIGTTOU` and the kernel stops QEMU before it prints anything.                                                        
                                                                                                          
The fix: redirect stdin from `/dev/null` in `boot.sh --test` mode. The guest never needs keyboard input during automated testing, so this is always safe, and it prevents QEMU from ever touching a real terminal.                                                                                               
                                                                                                          
CI never hit this because GitHub Actions runners don't have a TTY — `tcsetattr()` fails silently with `ENOTTY` inside a container.                                          
                                                                                                          
Tested both `test-modules.sh` (33 passed, 0 failed) and interactive `boot.sh` to confirm the fix doesn't break anything. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents QEMU from hanging in test mode when output is piped by redirecting stdin from `/dev/null`. This avoids `SIGTTOU` from `tcsetattr()` under `-nographic` so tests print output and complete.

- **Bug Fixes**
  - In `boot.sh --test`, exec QEMU with `< /dev/null` to avoid touching the real TTY.
  - Works with `tee` and `timeout(1)`; `devtools/test-modules.sh` passes, and interactive `boot.sh` is unchanged.

<sup>Written for commit 37cf3aa8b9abc374a633fb36f39a2cb13099317b. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/lkmpg/pull/378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

