### PR TITLE
Fix incorrect ioctl number field description

### DIFF
--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1823,7 +1823,7 @@ Here is an example:
 
 You can see there is an argument called \cpp|cmd| in \cpp|test_ioctl_ioctl()| function.
 It is the ioctl number.
-The ioctl number encodes the major device number, the type of the ioctl, the command, and the type of the parameter.
+The ioctl number encodes the direction of data transfer, the type of the ioctl, the command, and the type of the parameter.
 This ioctl number is usually created by a macro call (\cpp|_IO|, \cpp|_IOR|, \cpp|_IOW| or \cpp|_IOWR| --- depending on the type) in a header file.
 This header file should then be included both by the programs which will use ioctl (so they can generate the appropriate ioctl operations) and by the kernel module (so it can understand it).
 In the example below, the header file is \verb|chardev.h| and the program which uses it is \verb|userspace_ioctl.c|.


### PR DESCRIPTION
The original text says the ioctl number encodes the "major device number", which is incorrect. The ioctl number does not encode the major device number.

As the following sentence notes, the number is created by the `_IO`/`_IOR`/`_IOW`/`_IOWR` macros, which encode the **direction** of data transfer, the type (magic number), the command, and the size of the parameter.

Changed "major device number" to "direction of data transfer" so the description matches what these macros actually encode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ioctl number description in the docs: it encodes the direction of data transfer, not the major device number. Aligns the text with the `_IO`, `_IOR`, `_IOW`, and `_IOWR` macros.

<sup>Written for commit 90f0d96ef00eba98a3ca66068cd56502e591645b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/lkmpg/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

