### PR TITLE
Clarify grammar and typos in syscall section and syscall-steal.c

### DIFF
--- a/examples/syscall-steal.c
+++ b/examples/syscall-steal.c
@@ -98,15 +98,15 @@ static struct kprobe syscall_kprobe = {
 
 static unsigned long **sys_call_table_stolen;
 
-/* A pointer to the original system call. The reason we keep this, rather
- * than call the original function (sys_openat), is because somebody else
- * might have replaced the system call before us. Note that this is not
+/* A pointer to the original system call. We retain this instead of
+ * calling the original function (sys_openat), because another
+ * module might have replaced the system call before us. Note that this is not
  * 100% safe, because if another module replaced sys_openat before us,
  * then when we are inserted, we will call the function in that module -
  * and it might be removed before we are.
  *
  * Another reason for this is that we can not get sys_openat.
- * It is a static variable, so it is not exported.
+ * It is a static function, so it is not exported.
  */
 #ifdef CONFIG_ARCH_HAS_SYSCALL_WRAPPER
 static asmlinkage long (*original_call)(const struct pt_regs *);
@@ -114,14 +114,14 @@ static asmlinkage long (*original_call)(const struct pt_regs *);
 static asmlinkage long (*original_call)(int, const char __user *, int, umode_t);
 #endif
 
-/* The function we will replace sys_openat (the function called when you
- * call the open system call) with. To find the exact prototype, with
+/* Our replacement function for sys_openat (the function called when you
+ * call the open system call) . To find the exact prototype, with
  * the number and type of arguments, we find the original function first
  * (it is at fs/open.c).
  *
  * In theory, this means that we are tied to the current version of the
  * kernel. In practice, the system calls almost never change (it would
- * wreck havoc and require programs to be recompiled, since the system
+ * wreak havoc and require programs to be recompiled, since the system
  * calls are the interface between the kernel and the processes).
  */
 #ifdef CONFIG_ARCH_HAS_SYSCALL_WRAPPER

--- a/lkmpg.tex
+++ b/lkmpg.tex
@@ -1915,7 +1915,7 @@ But what if you want to do something unusual, to change the behavior of the syst
 Then, you are mostly on your own.
 
 Notice that this example has been unavailable since Linux v6.9.
-Specifically, after this \href{https://github.com/torvalds/linux/commit/1e3ad78334a69b36e107232e337f9d693dcc9df2#diff-4a16bf89a09b4f49669a30d54540f0b936ea0224dc6ee9edfa7700deb16c3e11R52}{commit}, due to the system call table changing the implementation from an indirect function call table to a switch statement for security issues, such as Branch History Injection (BHI) attack.
+Specifically, after this \href{https://github.com/torvalds/linux/commit/1e3ad78334a69b36e107232e337f9d693dcc9df2#diff-4a16bf89a09b4f49669a30d54540f0b936ea0224dc6ee9edfa7700deb16c3e11R52}{commit}, the system call table changed from an indirect function call table to a switch statement for security issues, such as mitigating Branch History Injection (BHI) attacks.
 See more information \href{https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2060909}{here}.
 
 Should one choose not to use a virtual machine, kernel programming can become risky.


### PR DESCRIPTION
Fix grammatical errors and typos in the syscall description section and the syscall-steal.c example file to improve readability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix grammar and wording in the syscall section and `examples/syscall-steal.c` to improve clarity and accuracy. Clarifies that `sys_openat` is a static function (not a variable), corrects “wreak havoc,” and rephrases the syscall table change to a switch for BHI mitigation in `lkmpg.tex`.

<sup>Written for commit 6932bb5fea420149a7ed7d6c3e65eabd72e6faa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/lkmpg/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

